### PR TITLE
avahi-autoipd: only consider ARP Probe packets

### DIFF
--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -1227,7 +1227,9 @@ static int loop(int iface, uint32_t addr) {
 
                 } else if (state == STATE_WAITING_PROBE || state == STATE_PROBING || state == STATE_WAITING_ANNOUNCE) {
                     /* Probe conflict */
-                    conflict = info.target_ip_address == addr && memcmp(hw_address, info.sender_hw_address, ETHER_ADDRLEN);
+                    conflict = info.target_ip_address == addr &&
+                               info.sender_ip_address == 0 &&
+                               memcmp(hw_address, info.sender_hw_address, ETHER_ADDRLEN);
 
                     if (conflict)
                         daemon_log(LOG_INFO, "Received conflicting probe ARP packet.");


### PR DESCRIPTION
during the probe phase avahi-autoipd must only select a new IP when
it receives an ARP Probe packet:

According to RFC3927, Section 2.2.1. Probe details:
> An ARP Request constructed this way with an all-zero 'sender IP 
> address' is referred to as an "ARP Probe".

and

> In addition, if during this period [checking if an address is already 
> in use] the host receives any ARP Probe where the packet's 'target IP
> address' is the address being probed for, and the packet's 'sender
> hardware address' is not the hardware address of the interface the
> host is attempting to configure, then the host MUST similarly treat
> this as an address conflict and select a new address as above.

When receiving an ARP packet during probe avahi-autoipd did not check
if the 'sender IP address' is all-zero and therefore if the packet is an
ARP Probe.

refs #6 