### PR TITLE
Use external gettext instead the glib one

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -417,7 +417,7 @@ IT_PROG_INTLTOOL([0.35.0])
 GETTEXT_PACKAGE=avahi
 AC_SUBST([GETTEXT_PACKAGE])
 AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[Gettext package])
-AM_GLIB_GNU_GETTEXT
+AM_GNU_GETTEXT([external])
 
 avahilocaledir='${prefix}/${DATADIRNAME}/locale'
 AC_SUBST(avahilocaledir)


### PR DESCRIPTION
gettextize is called without `--intl` option, so `AM_GNU_GETTEXT([external])` should be used instead of `AM_GNU_GETTEXT` for triggering internationalization support [1]. On systems lacking GNU gettext or a compatible gettext library internationalization will not be enabled.

Furthermore, building avahi fails for build system without glib:

``` sh
  error: possibly undefined macro:
         AM_GLIB_GNU_GETTEXT
```

Using `AM_GNU_GETTEXT([external])` allows us to build avahi on systems providing an external gettext library without depending on glib.

[1] http://www.elpro.pl/dokumentacje/596-gettext13
