### PR TITLE
Do not create a directory below /usr/share which does not have content

### DIFF
--- a/service-type-database/Makefile.am
+++ b/service-type-database/Makefile.am
@@ -19,7 +19,6 @@ EXTRA_DIST=build-db.in service-types
 
 pkglibdatadir=$(libdir)/avahi
 
-pkgdata_DATA=service-types
 pkglibdata_DATA=
 
 if HAVE_PYTHON


### PR DESCRIPTION
pkgdata_DATA is never used - it's pkglibdata_DATA in the other cases
