### PR TITLE
avahi-sharp: multi arch distributions have mono stuff generally not i…

### DIFF
--- a/avahi-sharp.pc.in
+++ b/avahi-sharp.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=@libdir@
+libdir=@prefix@/lib
 
 Name: avahi-sharp
 Description: Mono bindings for the Avahi mDNS/DNS-SD stack

--- a/avahi-sharp/Makefile.am
+++ b/avahi-sharp/Makefile.am
@@ -73,10 +73,10 @@ monodoc_DATA = avahi-sharp-docs.zip avahi-sharp-docs.tree avahi-sharp-docs.sourc
 endif
 
 install-data-hook: $(ASSEMBLY)
-	$(AM_V_GEN)MONO_SHARED_DIR=. $(GACUTIL) /i $(ASSEMBLY) /package avahi-sharp /gacdir $(libdir) /root $(DESTDIR)$(libdir)
+	$(AM_V_GEN)MONO_SHARED_DIR=. $(GACUTIL) /i $(ASSEMBLY) /package avahi-sharp /gacdir $(prefix)/lib /root $(DESTDIR)$(prefix)/lib
 
 uninstall-hook: $(ASSEMBLY)
-	$(AM_V_GEN)MONO_SHARED_DIR=. $(GACUTIL) /u avahi-sharp /package avahi-sharp /gacdir $(libdir) /root $(DESTDIR)$(libdir)
+	$(AM_V_GEN)MONO_SHARED_DIR=. $(GACUTIL) /u avahi-sharp /package avahi-sharp /gacdir $(prefix)/lib /root $(DESTDIR)$(prefix)/lib
 
 endif
 endif

--- a/avahi-ui-sharp/Makefile.am
+++ b/avahi-ui-sharp/Makefile.am
@@ -60,10 +60,10 @@ monodoc_DATA = avahi-ui-sharp-docs.zip avahi-ui-sharp-docs.tree avahi-ui-sharp-d
 endif
 
 install-data-hook: $(ASSEMBLY)
-	$(GACUTIL) /i $(ASSEMBLY) /package avahi-ui-sharp /gacdir $(libdir) /root $(DESTDIR)$(libdir)
+	$(GACUTIL) /i $(ASSEMBLY) /package avahi-ui-sharp /gacdir $(prefix)/lib /root $(DESTDIR)$(prefix)/lib
 
 uninstall-hook: $(ASSEMBLY)
-	$(GACUTIL) /u avahi-ui-sharp /package avahi-ui-sharp /gacdir $(libdir) /root $(DESTDIR)$(libdir)
+	$(GACUTIL) /u avahi-ui-sharp /package avahi-ui-sharp /gacdir $(prefix)/lib /root $(DESTDIR)$(prefix)/lib
 
 endif
 endif


### PR DESCRIPTION
…n libdir

On typical multiarch systems, libdir maps to /usr/lib64, the entire mono stack (*.dll) though
is not 64 bit and all mono assemblies are installed in /usr/lib/...
