### PR TITLE
g-i: reference the build shared object from the .gir file

### DIFF
--- a/avahi-gobject/AvahiCore-0.6.gir
+++ b/avahi-gobject/AvahiCore-0.6.gir
@@ -3,7 +3,7 @@
             xmlns="http://www.gtk.org/introspection/core/1.0"
             xmlns:c="http://www.gtk.org/introspection/c/1.0"
             xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
-  <namespace name="AvahiCore" version="0.6" shared-library="avahi-core">
+  <namespace name="AvahiCore" version="0.6" shared-library="libavahi-core.so.7">
     <alias name="IfIndex" c:type="AvahiIfIndex">
       <type name="gint" c:type="int"/>
     </alias>


### PR DESCRIPTION
openSUSE uses a dependency extractor for g-i typelibs that lists which shared libraries are referenced.

It was observed if the linking is not done the right way, generally we end up with weird dependencies (which g-i internally seems to somehow guess until it finds something that works).

Putting the right reference in place makes those things work (mageia uses the same extractor, fedora was discussing it)
