### PR TITLE
gobject: allow using custom context

### DIFF
--- a/avahi-gobject/ga-client.c
+++ b/avahi-gobject/ga-client.c
@@ -229,6 +229,10 @@ static void _avahi_client_cb(AvahiClient * c, AvahiClientState state, void *data
 }
 
 gboolean ga_client_start(GaClient * client, GError ** error) {
+    return ga_client_start_in_context(client, NULL, error);
+}
+
+gboolean ga_client_start_in_context(GaClient * client, GMainContext * context, GError ** error) {
     GaClientPrivate *priv = GA_CLIENT_GET_PRIVATE(client);
     AvahiClient *aclient;
     int aerror;
@@ -238,7 +242,7 @@ gboolean ga_client_start(GaClient * client, GError ** error) {
 
     avahi_set_allocator(avahi_glib_allocator());
 
-    priv->poll = avahi_glib_poll_new(NULL, G_PRIORITY_DEFAULT);
+    priv->poll = avahi_glib_poll_new(context, G_PRIORITY_DEFAULT);
 
     aclient = avahi_client_new(avahi_glib_poll_get(priv->poll),
                                priv->flags,

--- a/avahi-gobject/ga-client.h
+++ b/avahi-gobject/ga-client.h
@@ -73,6 +73,8 @@ GaClient *ga_client_new(GaClientFlags flags);
 
 gboolean ga_client_start(GaClient * client, GError ** error);
 
+gboolean ga_client_start_in_context(GaClient * client, GMainContext * context, GError ** error);
+
 G_END_DECLS
 
 #endif /* #ifndef __GA_CLIENT_H__ */


### PR DESCRIPTION
At first I was thinking about using
g_main_context_get_thread_default() instead of NULL in
ga_client_start(), but that would probably break other apps that
expect that client will be always running in the global default main
context.
