### PR TITLE
build: Allow autogen.sh to be run from another directory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -42,6 +42,13 @@ run_versioned() {
 
 set -ex
 
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
+
+olddir=$(pwd)
+
+cd $srcdir
+
 if [ -f .git/hooks/pre-commit.sample -a ! -f .git/hooks/pre-commit ] ; then
     cp -p .git/hooks/pre-commit.sample .git/hooks/pre-commit && \
     chmod +x .git/hooks/pre-commit && \
@@ -70,8 +77,9 @@ else
     run_versioned autoheader "$AC_VERSION"
     run_versioned automake "$AM_VERSION" -a -c --foreign
 
+    cd "$olddir"
     if test "x$NOCONFIGURE" = "x"; then
-        ./configure "$@"
+        $srcdir/configure "$@"
         make clean
     fi
 fi


### PR DESCRIPTION
This allows the build pattern:
   git clone …
   mkdir /tmp/build
   cd /tmp/build
   /path/to/checkout/autogen.sh
   make
which is useful for builddir ≠ srcdir setups, such as buildbots.