### PR TITLE
Include <poll.h> instead of <sys/poll.h>

### DIFF
--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -21,7 +21,7 @@
 #include <config.h>
 #endif
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>

--- a/avahi-common/simple-watch.h
+++ b/avahi-common/simple-watch.h
@@ -22,7 +22,7 @@
 
 /** \file simple-watch.h Simple poll() based main loop implementation */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <avahi-common/cdecl.h>
 #include <avahi-common/watch.h>
 

--- a/avahi-common/thread-watch.c
+++ b/avahi-common/thread-watch.c
@@ -21,7 +21,7 @@
 #include <config.h>
 #endif
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>

--- a/avahi-common/thread-watch.h
+++ b/avahi-common/thread-watch.h
@@ -22,7 +22,7 @@
 
 /** \file thread-watch.h Threaded poll() based main loop implementation */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <avahi-common/cdecl.h>
 #include <avahi-common/watch.h>
 

--- a/avahi-common/watch.h
+++ b/avahi-common/watch.h
@@ -22,7 +22,7 @@
 
 /** \file watch.h Simplistic main loop abstraction */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 
 #include <avahi-common/cdecl.h>


### PR DESCRIPTION
Both POSIX and the manpage for poll(2) says that `poll.h` should be
included, not `sys/poll.h`

http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html
http://man7.org/linux/man-pages/man2/poll.2.html

This fixes compile warning when building with musl libc.