### PR TITLE
Fix warnings on musl libc

### DIFF
--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -21,7 +21,7 @@
 #include <config.h>
 #endif
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>

--- a/avahi-common/simple-watch.h
+++ b/avahi-common/simple-watch.h
@@ -22,7 +22,7 @@
 
 /** \file simple-watch.h Simple poll() based main loop implementation */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <avahi-common/cdecl.h>
 #include <avahi-common/watch.h>
 

--- a/avahi-common/thread-watch.c
+++ b/avahi-common/thread-watch.c
@@ -21,7 +21,7 @@
 #include <config.h>
 #endif
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>

--- a/avahi-common/thread-watch.h
+++ b/avahi-common/thread-watch.h
@@ -22,7 +22,7 @@
 
 /** \file thread-watch.h Threaded poll() based main loop implementation */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <avahi-common/cdecl.h>
 #include <avahi-common/watch.h>
 

--- a/avahi-common/watch.h
+++ b/avahi-common/watch.h
@@ -22,7 +22,7 @@
 
 /** \file watch.h Simplistic main loop abstraction */
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 
 #include <avahi-common/cdecl.h>


### PR DESCRIPTION
poll.h is defined in POSIX and has existed since at least SUSv2.
Usage of sys/poll.h is a glibc-ism and produces warnings on musl, even
though they are the same header; the only difference is that poll.h
is guaranteed portable due to its standardization.