### PR TITLE
avahi-daemon.service.in: start after network-online

### DIFF
--- a/avahi-daemon/avahi-daemon.service.in
+++ b/avahi-daemon/avahi-daemon.service.in
@@ -18,6 +18,8 @@
 [Unit]
 Description=Avahi mDNS/DNS-SD Stack
 Requires=avahi-daemon.socket
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
We are seeing this in a log while beta testing SLE 12 SP2
May 31 11:16:35 linux avahi-daemon[801]: Failed to open /etc/resolv.conf: No such file or directory

So it appears that avahi-daemon wants resolv.conf to be set up correctly; maybe it makes sense to ensure that NetworkManager or wicked have started first.