### PR TITLE
Only warn on missing resolv.conf if the options that use it are enabled

### DIFF
--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -172,7 +172,11 @@ static int load_resolv_conf(void) {
 #endif
 
     if (!f) {
-        avahi_log_warn("Failed to open "RESOLV_CONF": %s", strerror(errno));
+        if ((config.publish_dns_servers && config.publish_dns_servers[0]) ||
+             config.publish_resolv_conf ||
+             config.server_config.publish_domain) {
+            avahi_log_warn("Failed to open "RESOLV_CONF": %s", strerror(errno));
+        }
         goto finish;
     }
 


### PR DESCRIPTION
If /etc/resolv.conf is missing (possibly because avahi started before wicked/NetworkManager), then we get a warning, but usually this warning is harmless.

Follow-up to https://github.com/lathiat/avahi/pull/59
