### PR TITLE
avahi-daemon: Start the daemon after network is up

### DIFF
--- a/avahi-daemon/avahi-daemon.service.in
+++ b/avahi-daemon/avahi-daemon.service.in
@@ -18,6 +18,8 @@
 [Unit]
 Description=Avahi mDNS/DNS-SD Stack
 Requires=avahi-daemon.socket
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
In case of ConnMan used as a network manager the file
/etc/resolve.conf isn't available for reading before
connmand is up and running. This precludes Avahi from
loading /etc/resolv.conf.

The patch makes avahi-daemon start after ConnMan is fully
initialized.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>