### PR TITLE
avahi-daemon: fix SIGHUP/SIGUSR1 race condition at startup

### DIFF
--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1646,6 +1646,13 @@ int main(int argc, char *argv[]) {
 #endif
         }
 
+        /* We may get signalled to reload / dump data before signal
+         * handlers are set up (in run_server()) and instead get
+         * killed as these signals default to terminate the process.
+         * Instead ignore them until we are ready */
+        ignore_signal(SIGHUP);
+        ignore_signal(SIGUSR1);
+
         if (daemon_pid_file_create() < 0) {
             avahi_log_error("Failed to create PID file: %s", strerror(errno));
 


### PR DESCRIPTION
We may get signalled to reload / dump data before signal handlers are set up
(in run_server()) and instead get killed as these signals default to
terminate the process.  Instead ignore them until we are ready

Signed-off-by: Peter Korsgaard peter@korsgaard.com
