### PR TITLE
Added support for binary TXT records in XML service definition

### DIFF
--- a/avahi-daemon/avahi-service.dtd
+++ b/avahi-daemon/avahi-service.dtd
@@ -16,3 +16,5 @@
 <!ATTLIST port>
 <!ELEMENT txt-record (#PCDATA)>
 <!ATTLIST txt-record>
+<!ELEMENT txt-binary (#PCDATA)>
+<!ATTLIST txt-binary>

--- a/man/avahi.service.5.xml.in
+++ b/man/avahi.service.5.xml.in
@@ -59,7 +59,8 @@
         <opt>&lt;domain-name&gt;</opt>, one
         <opt>&lt;host-name&gt;</opt>, any number of
         <opt>&lt;subtype&gt;</opt> and any number of
-        <opt>&lt;txt-record&gt;</opt> elements. The attribute
+        <opt>&lt;txt-record&gt;</opt> or
+	<opt>&lt;txt-binary&gt;</opt> elements. The attribute
         <opt>protocol</opt> specifies the protocol to advertise the
         service on. If <opt>any</opt> is used (which is the default),
         the service will be advertised on both IPv4 and IPv6.</p>
@@ -97,6 +98,11 @@
 
       <option>
         <p><opt>&lt;txt-record&gt;</opt> DNS-SD TXT record data.</p>
+      </option>
+      
+      <option>
+        <p><opt>&lt;txt-binary&gt;</opt> DNS-SD TXT binary record data. 
+	Each value octet after '=' is interpreted in base 16.</p>
       </option>
 
 


### PR DESCRIPTION
Solves #77.

Using the new **`<txt-binary>`** tag in the XML service definition, the value after '=' char is read as an hex binary and accordingly published. The code checks for the presence of '=' and for an even number of characters in the value part, but does not check for valid base 16 digits. The key and equals sign remain human readable.

Valid examples:
`<txt-binary>key=37ab</txt-binary>`
`<txt-binary>foo=abcDEF</txt-binary>` <-- Indistinct use of uppercase and lowercase

Invalid examples:
`<txt-binary>key37ab</txt-binary>` <-- Lack of equals sign
`<txt-binary>foo=abcDEFF</txt-binary>` <-- Odd number of value digits

Wrong behavior example:
`<txt-binary>key=12mb8</txt-binary>` <-- Non base 16 digit.
