### PR TITLE
Fix watch cleanup issue in watch_free.

### DIFF
--- a/avahi-glib/glib-watch.c
+++ b/avahi-glib/glib-watch.c
@@ -87,7 +87,7 @@ static void cleanup_watches(AvahiGLibPoll *g, int all) {
             destroy_watch(w);
     }
 
-    g->watch_req_cleanup = 0;
+    g->watch_req_cleanup = FALSE;
 }
 
 static gushort map_events_to_glib(AvahiWatchEvent events) {
@@ -160,7 +160,7 @@ static void watch_free(AvahiWatch *w) {
     }
 
     w->dead = TRUE;
-    w->glib_poll->timeout_req_cleanup = TRUE;
+    w->glib_poll->watch_req_cleanup = TRUE;
 }
 
 static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata) {


### PR DESCRIPTION
When an AvahiWatch instance `w` is freed by watch_free(), watch_free()
is supposed to set `w->glib_poll->watch_req_cleanup = TRUE` to trigger
cleanup_watches() during prepare_func(), but instead it incorrectly sets
`w->glib_poll->timeout_req_cleanup = TRUE`. Without invoking
cleanup_watches(), the AvahiWatch instance isn't properly destroyed and
its associated GSource instance isn't removed. The watch callback could
potentially be invoked inappropriately on the supposedly dead watch.