### PR TITLE
spelling fixes

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 AVAHI SERVICE DISCOVERY SUITE
 
 Avahi is a free, LGPL implementation of DNS Service Discovery (DNS-SD RFC 6763) over Multicast DNS (mDNS RFC 6762),
-commonly known as and compatible with Apple Bonjour primarily targetting Linux.
+commonly known as and compatible with Apple Bonjour primarily targeting Linux.
 
 Copyright 2004-2015 by the Avahi developers.
 

--- a/avahi-client/client-test.c
+++ b/avahi-client/client-test.c
@@ -163,7 +163,7 @@ static void avahi_host_name_resolver_callback (
 ar = avahi_address_resolver_new(client, interface, protocol, a, 0, avahi_address_resolver_callback, (char*) "omghai6u");
     if (ar)
     {
-        printf ("Succesfully created address resolver object\n");
+        printf ("Successfully created address resolver object\n");
     } else {
         printf ("Failed to create AddressResolver\n");
     }
@@ -253,7 +253,7 @@ int main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     assert(group);
 
-    printf("Sucessfully created entry group %p\n", (void*) group);
+    printf("Successfully created entry group %p\n", (void*) group);
 
     printf("%s\n", avahi_strerror(avahi_entry_group_add_service (group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, "Lathiat's Site", "_http._tcp", NULL, NULL, 80, "foo=bar", NULL)));
     printf("add_record: %d\n", avahi_entry_group_add_record (group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, "TestX", 0x01, 0x10, 120, "\5booya", 6));
@@ -265,19 +265,19 @@ int main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     if (domain == NULL)
         printf ("Failed to create domain browser object\n");
     else
-        printf ("Sucessfully created domain browser %p\n", (void*) domain);
+        printf ("Successfully created domain browser %p\n", (void*) domain);
 
     st = avahi_service_type_browser_new (avahi, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, NULL, 0, avahi_service_type_browser_callback, (char*) "omghai3u");
     if (st == NULL)
         printf ("Failed to create service type browser object\n");
     else
-        printf ("Sucessfully created service type browser %p\n", (void*) st);
+        printf ("Successfully created service type browser %p\n", (void*) st);
 
     sb = avahi_service_browser_new (avahi, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, "_http._tcp", NULL, 0, avahi_service_browser_callback, (char*) "omghai3u");
     if (sb == NULL)
         printf ("Failed to create service browser object\n");
     else
-        printf ("Sucessfully created service browser %p\n", (void*) sb);
+        printf ("Successfully created service browser %p\n", (void*) sb);
 
     hnr = avahi_host_name_resolver_new (avahi, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, "ecstasy.local", AVAHI_PROTO_UNSPEC, 0, avahi_host_name_resolver_callback, (char*) "omghai4u");
     if (hnr == NULL)

--- a/avahi-client/lookup.h
+++ b/avahi-client/lookup.h
@@ -177,7 +177,7 @@ typedef void (*AvahiServiceResolverCallback) (
  * callback function, especially interface and protocol. The protocol
  * argument specifies the protocol (IPv4 or IPv6) to use as transport
  * for the queries which are sent out by this resolver. The
- * aprotocol argument specifies the adress family (IPv4 or IPv6) of
+ * aprotocol argument specifies the address family (IPv4 or IPv6) of
  * the address of the service we are looking for. Generally, on
  * "protocol" you should only pass what was supplied to you as
  * parameter to your AvahiServiceBrowserCallback. In "aprotocol" you

--- a/avahi-common/error.h
+++ b/avahi-common/error.h
@@ -63,7 +63,7 @@ enum {
 
     AVAHI_ERR_NOT_FOUND = -30,               /**< Not found */
     AVAHI_ERR_INVALID_CONFIG = -31,          /**< Configuration error */
-    AVAHI_ERR_VERSION_MISMATCH = -32,        /**< Verson mismatch */
+    AVAHI_ERR_VERSION_MISMATCH = -32,        /**< Version mismatch */
     AVAHI_ERR_INVALID_SERVICE_SUBTYPE = -33, /**< Invalid service subtype */
     AVAHI_ERR_INVALID_PACKET = -34,          /**< Invalid packet */
     AVAHI_ERR_INVALID_DNS_ERROR = -35,       /**< Invlaid DNS return code */

--- a/avahi-common/strlst.h
+++ b/avahi-common/strlst.h
@@ -107,7 +107,7 @@ AvahiStringList *avahi_string_list_add_many_va(AvahiStringList *r, va_list va);
 /** @{ \name String list operations */
 
 /** Convert the string list object to a single character string,
- * seperated by spaces and enclosed in "". avahi_free() the result! This
+ * separated by spaces and enclosed in "". avahi_free() the result! This
  * function doesn't work well with strings that contain NUL bytes. */
 char* avahi_string_list_to_string(AvahiStringList *l);
 

--- a/avahi-common/watch.h
+++ b/avahi-common/watch.h
@@ -80,7 +80,7 @@ struct AvahiPoll {
     callback function when the absolute time *tv is reached. If tv is
     NULL, the timeout is disabled. After the timeout expired the
     callback function will be called and the timeout is disabled. You
-    can reenable it by calling timeout_update()  */
+    can re-enable it by calling timeout_update()  */
     AvahiTimeout* (*timeout_new)(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata);
 
     /** Update the absolute expiration time for a timeout, If tv is

--- a/avahi-compat-howl/warn.h
+++ b/avahi-compat-howl/warn.h
@@ -21,7 +21,7 @@
 ***/
 
 /* To avoid symbol name clashes when a process links to both our
- * compatiblity layers, we move the symbols out of the way here */
+ * compatibility layers, we move the symbols out of the way here */
 
 #define avahi_warn_unsupported avahi_warn_unsupported_HOWL
 #define avahi_warn_linkage avahi_warn_linkage_HOWL

--- a/avahi-compat-libdns_sd/dns_sd.h
+++ b/avahi-compat-libdns_sd/dns_sd.h
@@ -109,7 +109,7 @@ enum
     kDNSServiceFlagsDefault             = 0x4,
     /* Flags for domain enumeration and browse/query reply callbacks.
      * "Default" applies only to enumeration and is only valid in
-     * conjuction with "Add".  An enumeration callback with the "Add"
+     * conjunction with "Add".  An enumeration callback with the "Add"
      * flag NOT set indicates a "Remove", i.e. the domain is no longer
      * valid.
      */
@@ -684,7 +684,7 @@ DNSServiceErrorType DNSSD_API DNSServiceRegister
  *
  * sdRef:           A DNSServiceRef initialized by DNSServiceRegister().
  *
- * RecordRef:       A pointer to an uninitialized DNSRecordRef.  Upon succesfull completion of this
+ * RecordRef:       A pointer to an uninitialized DNSRecordRef.  Upon successful completion of this
  *                  call, this ref may be passed to DNSServiceUpdateRecord() or DNSServiceRemoveRecord().
  *                  If the above DNSServiceRef is passed to DNSServiceRefDeallocate(), RecordRef is also
  *                  invalidated and may not be used further.
@@ -1080,7 +1080,7 @@ DNSServiceErrorType DNSSD_API DNSServiceCreateConnection(DNSServiceRef *sdRef);
  *
  * sdRef:           A DNSServiceRef initialized by DNSServiceCreateConnection().
  *
- * RecordRef:       A pointer to an uninitialized DNSRecordRef.  Upon succesfull completion of this
+ * RecordRef:       A pointer to an uninitialized DNSRecordRef.  Upon successful completion of this
  *                  call, this ref may be passed to DNSServiceUpdateRecord() or DNSServiceRemoveRecord().
  *                  (To deregister ALL records registered on a single connected DNSServiceRef
  *                  and deallocate each of their corresponding DNSServiceRecordRefs, call
@@ -1708,7 +1708,7 @@ DNSServiceErrorType DNSSD_API DNSServiceSetDefaultDomainForUser
 // and report errors at compile-time if anything is wrong. The usual way to do this would
 // be to use a run-time "if" statement or the conventional run-time "assert" mechanism, but
 // then you don't find out what's wrong until you run the software. This way, if the assertion
-// condition is false, the array size is negative, and the complier complains immediately.
+// condition is false, the array size is negative, and the compiler complains immediately.
 
 struct DNS_SD_CompileTimeAssertionChecks
 	{

--- a/avahi-core/iface-linux.c
+++ b/avahi-core/iface-linux.c
@@ -239,7 +239,7 @@ static void netlink_callback(AvahiNetlink *nl, struct nlmsghdr *n, void* userdat
             a = RTA_NEXT(a, l);
         }
 
-        /* If there was no adress attached to this message, let's quit. */
+        /* If there was no address attached to this message, let's quit. */
         if (rlocal_valid)
             r = &rlocal;
         else if (raddr_valid)
@@ -387,5 +387,5 @@ void avahi_interface_monitor_sync(AvahiInterfaceMonitor *m) {
             break;
 
     /* At this point Avahi knows about all local interfaces and
-     * addresses in existance. */
+     * addresses in existence. */
 }

--- a/avahi-core/lookup.h
+++ b/avahi-core/lookup.h
@@ -43,7 +43,7 @@ typedef struct AvahiSServiceTypeBrowser AvahiSServiceTypeBrowser;
 /** A DNS-SD service browser. Use this to enumerate available services of a certain kind on the local LAN. Use AvahiSServiceResolver to get specific service data like address and port for a service. */
 typedef struct AvahiSServiceBrowser AvahiSServiceBrowser;
 
-/** A DNS-SD service resolver.  Use this to retrieve addres, port and TXT data for a DNS-SD service */
+/** A DNS-SD service resolver.  Use this to retrieve address, port and TXT data for a DNS-SD service */
 typedef struct AvahiSServiceResolver AvahiSServiceResolver;
 
 #include <avahi-common/cdecl.h>
@@ -86,7 +86,7 @@ typedef void (*AvahiSHostNameResolverCallback)(
     AvahiLookupResultFlags flags,  /**< Lookup flags */
     void* userdata);
 
-/** Create an AvahiSHostNameResolver object for resolving a host name to an adddress. See AvahiSRecordBrowser for more info on the paramters. */
+/** Create an AvahiSHostNameResolver object for resolving a host name to an adddress. See AvahiSRecordBrowser for more info on the parameters. */
 AvahiSHostNameResolver *avahi_s_host_name_resolver_new(
     AvahiServer *server,
     AvahiIfIndex interface,
@@ -111,7 +111,7 @@ typedef void (*AvahiSAddressResolverCallback)(
     AvahiLookupResultFlags flags,  /**< Lookup flags */
     void* userdata);
 
-/** Create an AvahiSAddressResolver object. See AvahiSRecordBrowser for more info on the paramters. */
+/** Create an AvahiSAddressResolver object. See AvahiSRecordBrowser for more info on the parameters. */
 AvahiSAddressResolver *avahi_s_address_resolver_new(
     AvahiServer *server,
     AvahiIfIndex interface,

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -294,7 +294,7 @@ static void elapse_callback(AVAHI_GCC_UNUSED AvahiTimeEvent *e, void* data) {
 
     n = 0;
 
-    /* Now add the chosen records to the authorative section */
+    /* Now add the chosen records to the authoritative section */
     for (pj = s->jobs; pj; pj = next) {
 
         next = pj->jobs_next;

--- a/avahi-core/response-sched.c
+++ b/avahi-core/response-sched.c
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "rr-util.h"
 
-/* Local packets are supressed this long after sending them */
+/* Local packets are suppressed this long after sending them */
 #define AVAHI_RESPONSE_HISTORY_MSEC 500
 
 /* Local packets are deferred this long before sending them */
@@ -207,7 +207,7 @@ static int packet_add_response_job(AvahiResponseScheduler *s, AvahiDnsPacket *p,
         return 0;
 
     /* Ok, this record will definitely be sent, so schedule the
-     * auxilliary packets, too */
+     * auxiliary packets, too */
     avahi_server_enumerate_aux_records(s->interface->monitor->server, s->interface, rj->record, enumerate_aux_records_callback, rj);
     job_mark_done(s, rj);
 
@@ -431,7 +431,7 @@ void avahi_response_scheduler_incoming(AvahiResponseScheduler *s, AvahiRecord *r
     assert(s);
 
     /* This function is called whenever an incoming response was
-     * receieved. We drop scheduled responses which match here. The
+     * received. We drop scheduled responses which match here. The
      * keyword is "DUPLICATE ANSWER SUPPRESION". */
 
     if ((rj = find_scheduled_job(s, record))) {

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -282,7 +282,7 @@ static int handle_conflict(AvahiServer *s, AvahiInterface *i, AvahiRecord *recor
         if (avahi_record_equal_no_ttl(e->record, record)) {
             ours = 1; /* We have an identical record, so this is no conflict */
 
-            /* Check wheter there is a TTL conflict */
+            /* Check whether there is a TTL conflict */
             if (record->ttl <= e->record->ttl/2 &&
                 avahi_entry_is_registered(s, e, i)) {
                 char *t;

--- a/avahi-dnsconfd/avahi-dnsconfd.action
+++ b/avahi-dnsconfd/avahi-dnsconfd.action
@@ -30,7 +30,7 @@ test "x$AVAHI_INTERFACE" != "x"
 # Available environment variables:
 #
 #   $AVAHI_INTERFACE               The interface name where this DNS server was found on
-#   $AVAHI_INTERFACE_DNS_SERVERS   A whitespace seperated list of DNS servers on $AVAHI_INTERFACE
+#   $AVAHI_INTERFACE_DNS_SERVERS   A whitespace separated list of DNS servers on $AVAHI_INTERFACE
 #   $AVAHI_DNS_SERVERS             The complete list of all DNS servers found on all interfaces
 
 if [ -x /sbin/netconfig ]; then

--- a/common/doxygen.m4
+++ b/common/doxygen.m4
@@ -10,7 +10,7 @@
 # DX_???_FEATURE(ON|OFF) - control the default setting fo a Doxygen feature.
 # Supported features are 'DOXYGEN' itself, 'DOT' for generating graphics,
 # 'HTML' for plain HTML, 'CHM' for compressed HTML help (for MS users), 'CHI'
-# for generating a seperate .chi file by the .chm file, and 'MAN', 'RTF',
+# for generating a separate .chi file by the .chm file, and 'MAN', 'RTF',
 # 'XML', 'PDF' and 'PS' for the appropriate output formats. The environment
 # variable DOXYGEN_PAPER_SIZE may be specified to override the default 'a4wide'
 # paper size.
@@ -239,8 +239,8 @@ DX_ARG_ABLE(chm, [generate doxygen compressed HTML help documentation],
              DX_ENV_APPEND(GENERATE_HTMLHELP, YES)],
             [DX_ENV_APPEND(GENERATE_HTMLHELP, NO)])
 
-# Seperate CHI file generation.
-DX_ARG_ABLE(chi, [generate doxygen seperate compressed HTML help index file],
+# Separate CHI file generation.
+DX_ARG_ABLE(chi, [generate doxygen separate compressed HTML help index file],
             [DX_CHECK_DEPEND(chm, 1)],
             [DX_CLEAR_DEPEND(chm, 1)],
             [],

--- a/common/gcc_stack_protect.m4
+++ b/common/gcc_stack_protect.m4
@@ -5,7 +5,7 @@ dnl 1.1 - August 2006 - Ted Percival <ted@midg3t.net>
 dnl     * Stricter language checking (C or C++)
 dnl     * Adds GCC_STACK_PROTECT_LIB to add -lssp to LDFLAGS as necessary
 dnl     * Caches all results
-dnl     * Uses macros to ensure correct ouput in quiet/silent mode
+dnl     * Uses macros to ensure correct output in quiet/silent mode
 dnl 1.2 - April 2007 - Ted Percival <ted@midg3t.net>
 dnl     * Added GCC_STACK_PROTECTOR macro for simpler (one-line) invocation
 dnl     * GCC_STACK_PROTECT_LIB now adds -lssp to LIBS rather than LDFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -312,7 +312,7 @@ if test "x$GCC" = "xyes" ; then
 
     if test "x$HAVE_NETLINK" = "xyes" ; then
         # Test whether rtnetlink.h can be included when compiled with -std=c99
-        # some distributions (e.g. archlinux) have broken headers that dont
+        # some distributions (e.g. archlinux) have broken headers that don't
         # define __u64 with -std=c99
         AC_MSG_CHECKING([checking whether rtnetlink.h can be included with -std=c99])
         OLDCFLAGS="$CFLAGS"
@@ -1022,7 +1022,7 @@ if test x$manpages = xyes ; then
 
     if test x$have_xmltoman = xno -o x$xmltoman = xno; then
         if ! test -e $srcdir/man/avahi-daemon.8 ; then
-            AC_MSG_ERROR([*** xmltoman was not found or was disabled, it is required to build the manpages as they have not been pre-built, install xmltoman, pass --disable-manpages or dont pass --disable-xmltoman])
+            AC_MSG_ERROR([*** xmltoman was not found or was disabled, it is required to build the manpages as they have not been pre-built, install xmltoman, pass --disable-manpages or don't pass --disable-xmltoman])
             exit 1
         fi
         AC_MSG_WARN([*** Not rebuilding man pages as xmltoman is not found ***])

--- a/docs/HACKING
+++ b/docs/HACKING
@@ -1,6 +1,6 @@
 Please comply with the following rules when hacking on Avahi:
 
- * Before commiting check with "git st" that all built files are ignored
+ * Before committing check with "git st" that all built files are ignored
    by git. To change the list of ignored files use
 
        $VISUAL .gitignore
@@ -20,7 +20,7 @@ Please comply with the following rules when hacking on Avahi:
 
  * Never forget that Avahi should be buildable without DBUS, GTK or python!
 
- * Before commiting, test your code! In case of C consider running it
+ * Before committing, test your code! In case of C consider running it
    a few times through valgrind, to make sure that you got everything
    right.  You have to call libtool explicitly when running valgrind
    on binaries that depend on shared objects. e.g:

--- a/docs/MALLOC
+++ b/docs/MALLOC
@@ -1,4 +1,4 @@
-Avahi supports pluggable memory allocator implemenations. See
+Avahi supports pluggable memory allocator implementations. See
 <avahi-common/malloc.h> for more information.
 
 Currently, Avahi does not deal well with out-of-memory

--- a/docs/NEWS
+++ b/docs/NEWS
@@ -318,7 +318,7 @@ from the last release
    defined (Closes: #86)
  * Fix doxygen comments for avahi watch, thanks to tedp (Closes: #77)
  * Make d-bus version detection work for >= 1.0 (Closes: #71)
- * Dont dbus_connection_close on shared dbus connections (Closes: #68)
+ * Don't dbus_connection_close on shared dbus connections (Closes: #68)
  * Fix potential endless loop in dns label unpacking code (Closes: #84)
  * Fix bogus assertion in client-publish-service.c example
  * Mild fix to some doxygen docs for avahi-common/address.h
@@ -403,7 +403,7 @@ Changes:
         * Implement subtype registration in DNSServiceRegister() in a
           way that is compatible with Bonjour.
 	* Update to newer copy of dns_sd.h
-  * If the host name changes update names of static services wich
+  * If the host name changes update names of static services which
     contain wildcards.
   * Don't build documentation about embedding the Avahi mDNS stack into
     other programs by default. This is a feature used only by embedded
@@ -546,7 +546,7 @@ This release fixes some bugs and adds a few new features
  * Don't require X11 to run avahi-bookmarks
  * API: Return AVAHI_ERR_IS_EMPTY when the user tries to commit an
    empty entry group.
- * Improved Slackware and Fedora suppport
+ * Improved Slackware and Fedora support
 
 This release is backwards compatible with Avahi 0.6, 0.6.1, 0.6.2,
 0.6.3, 0.6.4, 0.6.5 and 0.6.6.
@@ -561,7 +561,7 @@ This release fixes some bugs and includes some documentation updates
  * Many doxygen documentation improvements
  * Fix destruction of AvahiEntryGroup objects using
    avahi_entry_group_free().
- * Don't allow commiting of empty entry groups
+ * Don't allow committing of empty entry groups
  * Use a little less memory in avahi-qt
  * Don't accept empty TXT strings
  * Update example "client-publish-service.c" to show how to modify an
@@ -826,7 +826,7 @@ and boasts the following features
    Howl and Apple Bonjour (previously Rendezvous)
  * Ability to correctly "reflect" mDNS between two or more LAN segments
  * Ability to configure DNS servers based on mDNS/DNS-SD published
-   information, a feature that is very usefull on IPv6
+   information, a feature that is very useful on IPv6
    which has no other mechanism for this.
  * Combined with nss-mdns, allows hostname lookup such as
    'laptop.local' without the configuration of a DNS server.

--- a/docs/TODO
+++ b/docs/TODO
@@ -49,12 +49,12 @@ done:
 * add SRV and TXT records referenced from PTR records automatically to packet
 * add A and AAAA records referenced from SRV records automatically to packet
 * support known answer suppresion for incoming unicast queries
-* check wether RRsets are supported correctly (i.e. that all records of an
+* check whether RRsets are supported correctly (i.e. that all records of an
   RRset are really sent if it is requested) (rfc 2181)
 * case insensitve comparison
 * drop records from cache only one second after flush cache bit entry was received
 * either send entire RRSET or don't set flush cache bit!
-* mantain flush cache bit correctly in psched
+* maintain flush cache bit correctly in psched
 * Return to probing state on conflict
 * response job dependencies
 * enlarge packet in case a record/query is too large to fit in a normal packet

--- a/examples/client-browse-services.c
+++ b/examples/client-browse-services.c
@@ -164,7 +164,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char*argv[]) {
     /* Allocate a new client */
     client = avahi_client_new(avahi_simple_poll_get(simple_poll), 0, client_callback, NULL, &error);
 
-    /* Check wether creating the client object succeeded */
+    /* Check whether creating the client object succeeded */
     if (!client) {
         fprintf(stderr, "Failed to create client: %s\n", avahi_strerror(error));
         goto fail;

--- a/examples/core-browse-services.c
+++ b/examples/core-browse-services.c
@@ -180,7 +180,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char*argv[]) {
     /* Free the configuration data */
     avahi_server_config_free(&config);
 
-    /* Check wether creating the server object succeeded */
+    /* Check whether creating the server object succeeded */
     if (!server) {
         fprintf(stderr, "Failed to create server: %s\n", avahi_strerror(error));
         goto fail;

--- a/examples/glib-integration.c
+++ b/examples/glib-integration.c
@@ -123,7 +123,7 @@ main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[])
     /* Make a call to get the version string from the daemon */
     version = avahi_client_get_version_string (client);
 
-    /* Check if the call suceeded */
+    /* Check if the call succeeded */
     if (version == NULL)
     {
         g_warning ("Error getting version string: %s", avahi_strerror (avahi_client_errno (client)));

--- a/man/avahi-bookmarks.1.xml.in
+++ b/man/avahi-bookmarks.1.xml.in
@@ -51,7 +51,7 @@
       <option>
         <p><opt>-H | --host-names</opt></p>
         <optdesc><p>Create links pointing to mDNS host names instead
-        of resolved IP addreses. This is only compatible with your
+        of resolved IP addresses. This is only compatible with your
         browser if you run some kind of local NSS module to resolve
         mDNS host names (e.g. nss-mdns). If both -A and -H are ommited
         avahi-bookmarks detects whether NSS support is available

--- a/man/avahi.service.5.xml.in
+++ b/man/avahi.service.5.xml.in
@@ -45,7 +45,7 @@
       <option>
         <p><opt>&lt;name replace-wildcards="yes|no"&gt;</opt> The
         service name. If <opt>replace-wildcards</opt> is "yes", any
-        occurence of the string "%h" will be replaced by the local
+        occurrence of the string "%h" will be replaced by the local
         host name. This can be used for service names like "Remote
         Terminal on %h". If <opt>replace-wildcards</opt> is not
         specified, defaults to "no".</p>


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.