### PR TITLE
avahi-autoipd: clear previously set address before binding a new one

### DIFF
--- a/avahi-autoipd/avahi-autoipd.action.linux
+++ b/avahi-autoipd/avahi-autoipd.action.linux
@@ -41,6 +41,7 @@ if [ -x /bin/ip -o -x /sbin/ip ] ; then
 
     case "$1" in
         BIND)
+            ip addr flush dev "$2" label "$2:avahi"
             ip addr add "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
             ip route add default dev "$2" metric "$METRIC" scope link ||:
             ;;


### PR DESCRIPTION
Delete any IP addresses set to the avahi alias/label before setting a new
so we do not end-up with multiple IP addresses

See https://github.com/lathiat/avahi/issues/111

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>