### PR TITLE
filter denied virtual interfaces when adding addresses

### DIFF
--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -675,25 +675,30 @@ static int avahi_interface_is_relevant_internal(AvahiInterface *i) {
     return 0;
 }
 
+int avahi_interface_label_is_relevant(AvahiInterface *i, const char *label) {
+    AvahiStringList *l;
+    assert(i);
+    assert(label);
+
+    for (l = i->monitor->server->config.deny_interfaces; l; l = l->next)
+        if (strcasecmp((char*) l->text, label) == 0)
+            return 0;
+    if (!i->monitor->server->config.allow_interfaces)
+        return 1;
+    for (l = i->monitor->server->config.allow_interfaces; l; l = l->next)
+        if (strcasecmp((char*)l->text, label) == 0)
+            return 1;
+    return 0;
+}
+
 int avahi_interface_is_relevant(AvahiInterface *i) {
     AvahiStringList *l;
     assert(i);
 
-    for (l = i->monitor->server->config.deny_interfaces; l; l = l->next)
-        if (strcasecmp((char*) l->text, i->hardware->name) == 0)
-            return 0;
-
-    if (i->monitor->server->config.allow_interfaces) {
-
-        for (l = i->monitor->server->config.allow_interfaces; l; l = l->next)
-            if (strcasecmp((char*) l->text, i->hardware->name) == 0)
-                goto good;
-
+    if (avahi_interface_label_is_relevant(i, i->hardware->name))
+        return avahi_interface_is_relevant_internal(i);
+    else
         return 0;
-    }
-
-good:
-    return avahi_interface_is_relevant_internal(i);
 }
 
 int avahi_interface_address_is_relevant(AvahiInterfaceAddress *a) {

--- a/avahi-core/iface.h
+++ b/avahi-core/iface.h
@@ -164,6 +164,7 @@ void avahi_interface_free(AvahiInterface *i, int send_goodbye);
 
 void avahi_interface_update_rrs(AvahiInterface *i, int remove_rrs);
 void avahi_interface_check_relevant(AvahiInterface *i);
+int avahi_interface_label_is_relevant(AvahiInterface *i, const char *label);
 int avahi_interface_is_relevant(AvahiInterface *i);
 
 void avahi_interface_send_packet(AvahiInterface *i, AvahiDnsPacket *p);


### PR DESCRIPTION
netlink does not send an interface change notification when setting up a virtual
interface such as eth0:0: that information is only available in RTM_NEWADDR
messages.

It is therefore needed to check if a new address does belong to an allowed
interface label before actually adding it to the hardware interface.

Fixes #103 