### PR TITLE
Update po/LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -27,14 +27,15 @@ ko
 lv
 ms
 nl
+oc
 pl
 pt_BR
 ro
 ru
 sk
 sl
-sr@latin
 sr
+sr@latin
 sv
 tr
 uk


### PR DESCRIPTION
The new Occitan translation is missing from po/LINGUAS, which causes it not to be used at all.