### PR TITLE
python: Added a txt_array_to_dict functions

### DIFF
--- a/avahi-python/avahi/__init__.py
+++ b/avahi-python/avahi/__init__.py
@@ -110,3 +110,22 @@ def dict_to_txt_array(txt_dict):
         l.append(string_to_byte_array("%s=%s" % (k,v)))
 
     return l
+
+
+def txt_array_to_dict(self, txt_array):
+    txt_dict = {}
+    for els in txt_array:
+        key, val = '', None
+        for c in els:
+            c = chr(c)
+            if val is None:
+                if c == '=':
+                    val = ''
+                else:
+                    key += c
+            else:
+                val += c
+        if val is None: # missing '='
+            val = ''
+        txt_dict[key] = val
+    return txt_dict


### PR DESCRIPTION
Avahi consumers seem to cargo-cult this functionality
from across projects, e.g. https://dev.gajim.org/gajim/gajim/blob/master/gajim/common/zeroconf/zeroconf_avahi.py#L131
It does indeed seem reasonably to have Avahi ship this function,
so this patch includes it.