### PR TITLE
Fix logic error in server_callback()

### DIFF
--- a/examples/core-publish-service.c
+++ b/examples/core-publish-service.c
@@ -168,12 +168,14 @@ static void server_callback(AvahiServer *s, AvahiServerState state, AVAHI_GCC_UN
 
         case AVAHI_SERVER_REGISTERING:
 
-	    /* Let's drop our registered services. When the server is back
+            /* Let's drop our registered services. When the server is back
              * in AVAHI_SERVER_RUNNING state we will register them
              * again with the new host name. */
-            if (group)
+            if (group) {
                 avahi_s_entry_group_reset(group);
-
+                avahi_s_entry_group_free(group);
+                group = NULL;
+            }
             break;
 
         case AVAHI_SERVER_FAILURE:


### PR DESCRIPTION
server_callback() follows logic to handle AVAHI_SERVER_COLLISION and AVAHI_SERVER_REGISTERING states with an unregister of the service group, but does not reset the pointer to the group to NULL. Added a avahi_s_entry_group_free(group) and reset of the pointer to NULL to ensure the re-registration succeeds.

This is to resolve issue #135.