### PR TITLE
avahi-daemon: fix segfault when parsing static service XML with TXT r…

### DIFF
--- a/avahi-daemon/example.service
+++ b/avahi-daemon/example.service
@@ -29,6 +29,24 @@
   <service>
     <type>_printer._tcp</type>
     <port>515</port>
+    
+    <!-- TXT records without value-->    
+    <txt-record>legacyKeyWithNoValue</txt-record>
+    <txt-record value-format="text">textKeyWithNoValue</txt-record>
+    <txt-record value-format="binary-hex">hexKeyWithNoValue</txt-record>
+    <txt-record value-format="binary-base64">base64KeyWithNoValue</txt-record>
+    
+    <!-- TXT records with empty value-->
+    <txt-record>legacyKeyWithEmptyValue=</txt-record>
+    <txt-record value-format="text">textKeyWithEmptyValue=</txt-record>
+    <txt-record value-format="binary-hex">hexKeyWithEmptyValue=</txt-record>
+    <txt-record value-format="binary-base64">base64KeyWithEmptyValue=</txt-record>
+    
+    <!-- TXT records with value-->
+    <txt-record>legacyKey=value</txt-record>
+    <txt-record value-format="text">textKey=value</txt-record>
+    <txt-record value-format="binary-hex">hexKey=76616c7565</txt-record>
+    <txt-record value-format="binary-base64">base64Key=dmFsdWU=</txt-record>
   </service>
 
   <service>


### PR DESCRIPTION
…ecords key with empty value

Adding support of TXT record value-format introduced regression causing the daemon to segfault when .service files contained key with empty value.
ex:
`<txt-record>keyWithEmptyValue=</txt-record>`

Fix tested with TXT record:
 - without value,
 - with empty value,
 - with value
Each time without value-format and with value format set to "text", "binary-hex" and "binary-base64".

Also updating example.service.