### PR TITLE
Ship avahi-discover(1), bssh(1) and bvnc(1) also for GTK3

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -56,7 +56,7 @@ man_MANS += \
 	avahi-publish.1 \
 	avahi-set-host-name.1
 
-if HAVE_GTK
+if HAVE_GTK2OR3
 man_MANS += \
 	bssh.1
 endif
@@ -64,10 +64,11 @@ endif
 if HAVE_PYTHON
 man_MANS += \
 	avahi-bookmarks.1
-if HAVE_GTK
+endif
+
+if HAVE_PYGOBJECT
 man_MANS += \
 	avahi-discover.1
-endif
 endif
 endif
 
@@ -134,7 +135,7 @@ EXTRA_DIST = \
 if HAVE_DBUS
 
 BSSH_LN =
-if HAVE_GTK
+if HAVE_GTK2OR3
 if HAVE_GLIB
 BSSH_LN += $(LN_S) bssh.1 bvnc.1 &&
 endif


### PR DESCRIPTION
These manpages went missing when you disabled gtk2 builds....