### PR TITLE
man: fix reference to avahi-autoipd.action(8) in avahi-autoipd(8)

### DIFF
--- a/man/avahi-autoipd.8.xml.in
+++ b/man/avahi-autoipd.8.xml.in
@@ -150,7 +150,7 @@
 
 	<section name="See also">
 	  <p>
-        <manref name="autoipd.action" section="8"/>, <manref name="dhclient" section="8"/>
+        <manref name="avahi-autoipd.action" section="8"/>, <manref name="dhclient" section="8"/>
 	  </p>
 
       <p>http://avahi.org/wiki/AvahiAutoipd documents how avahi-autoipd is best packaged and integrated into distributions.</p>


### PR DESCRIPTION
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840833