### PR TITLE
man: add missing bshell.1 symlink

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -137,12 +137,13 @@ BSSH_LN =
 if HAVE_GTK
 if HAVE_GLIB
 BSSH_LN += $(LN_S) bssh.1 bvnc.1 &&
+BSSH_LN += $(LN_S) bssh.1 bshell.1 &&
 endif
 endif
 install-exec-local:
 	mkdir -p $(DESTDIR)/$(mandir)/man1 && \
 		cd $(DESTDIR)/$(mandir)/man1 && \
-		rm -f avahi-resolve-host-name.1 avahi-resolve-address.1 avahi-browse-domains.1 avahi-publish-address.1 avahi-publish-service.1 bvnc.1 && \
+		rm -f avahi-resolve-host-name.1 avahi-resolve-address.1 avahi-browse-domains.1 avahi-publish-address.1 avahi-publish-service.1 bvnc.1 bshell.1 && \
 		$(BSSH_LN) \
 		$(LN_S) avahi-resolve.1 avahi-resolve-host-name.1 && \
 		$(LN_S) avahi-resolve.1 avahi-resolve-address.1 && \


### PR DESCRIPTION
The bshell binary is missing a symlink to its manual page. It should be
symlinked to the man page for bssh, just like how the bvnc man page is.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=655190