### PR TITLE
Fix segfaults from strcmp in multithreaded apps

### DIFF
--- a/avahi-client/browser.c
+++ b/avahi-client/browser.c
@@ -820,7 +820,7 @@ AvahiRecordBrowser* avahi_record_browser_new(
     b->client = client;
     b->callback = callback;
     b->userdata = userdata;
-    b->path = NULL;
+    b->path = "";
     b->name = NULL;
     b->clazz = clazz;
     b->type = type;


### PR DESCRIPTION
At various places in the code, b->path is involved in a string compare. By initialising path to NULL, and adding it to the linked list immediately, it is possible that strcmp uses a NULL ptr for its comparison (by code on other threads) before the path is properly assigned by the avahi_strdup call. This fix ensures the empty string is used for all operations.