### PR TITLE
Avahi: Protected strcmp against NULL pointers in multithreaded apps

### DIFF
--- a/avahi-client/browser.c
+++ b/avahi-client/browser.c
@@ -281,7 +281,7 @@ DBusHandlerResult avahi_domain_browser_event (AvahiClient *client, AvahiBrowserE
         goto fail;
 
     for (db = client->domain_browsers; db; db = db->domain_browsers_next)
-        if (strcmp (db->path, path) == 0)
+        if (db->path && strcmp (db->path, path) == 0)
             break;
 
     if (!db)
@@ -502,7 +502,7 @@ DBusHandlerResult avahi_service_type_browser_event (AvahiClient *client, AvahiBr
         goto fail;
 
     for (b = client->service_type_browsers; b; b = b->service_type_browsers_next)
-        if (strcmp (b->path, path) == 0)
+        if (b->path && strcmp (b->path, path) == 0)
             break;
 
     if (!b)
@@ -721,7 +721,7 @@ DBusHandlerResult avahi_service_browser_event(AvahiClient *client, AvahiBrowserE
         goto fail;
 
     for (b = client->service_browsers; b; b = b->service_browsers_next)
-        if (strcmp (b->path, path) == 0)
+        if (b->path && strcmp (b->path, path) == 0)
             break;
 
     if (!b)
@@ -940,7 +940,7 @@ DBusHandlerResult avahi_record_browser_event(AvahiClient *client, AvahiBrowserEv
         goto fail;
 
     for (b = client->record_browsers; b; b = b->record_browsers_next)
-        if (strcmp (b->path, path) == 0)
+        if (b->path && strcmp (b->path, path) == 0)
             break;
 
     if (!b)

--- a/avahi-client/client.c
+++ b/avahi-client/client.c
@@ -193,7 +193,7 @@ static DBusHandlerResult filter_func(DBusConnection *bus, DBusMessage *message, 
         path = dbus_message_get_path(message);
 
         for (g = client->groups; g; g = g->groups_next)
-            if (strcmp(g->path, path) == 0)
+            if (g->path && strcmp(g->path, path) == 0)
                 break;
 
         if (g) {

--- a/avahi-client/resolver.c
+++ b/avahi-client/resolver.c
@@ -53,7 +53,7 @@ DBusHandlerResult avahi_service_resolver_event (AvahiClient *client, AvahiResolv
         goto fail;
 
     for (r = client->service_resolvers; r; r = r->service_resolvers_next)
-        if (strcmp (r->path, path) == 0)
+        if (r->path && strcmp (r->path, path) == 0)
             break;
 
     if (!r)
@@ -358,7 +358,7 @@ DBusHandlerResult avahi_host_name_resolver_event (AvahiClient *client, AvahiReso
         goto fail;
 
     for (r = client->host_name_resolvers; r; r = r->host_name_resolvers_next)
-        if (strcmp (r->path, path) == 0)
+        if (r->path && strcmp (r->path, path) == 0)
             break;
 
     if (!r)
@@ -577,7 +577,7 @@ DBusHandlerResult avahi_address_resolver_event (AvahiClient *client, AvahiResolv
         goto fail;
 
     for (r = client->address_resolvers; r; r = r->address_resolvers_next)
-        if (strcmp (r->path, path) == 0)
+        if (r->path && strcmp (r->path, path) == 0)
             break;
 
     if (!r)


### PR DESCRIPTION
A bug is triggered when a dbus message arrives, but the Avahi library
hasn't completed initialisation of a browser object (AvahiRecordBrowser
and potentially AvahiServiceTypeBrowser). Until initialisation has
completed, any dbus message that attempts to interrogate a browser
linked list (domain_browsers/service_type_browsers) will issue a segfault.

At various places in the code, b->path is involved in a string compare. By
initialising path to NULL, and adding it to the linked list immediately,
it is possible that strcmp uses a NULL ptr for its comparison (by code on
other threads) before the path is properly assigned by the avahi_strdup
call.

This fix checks for NULL before it is used.

Signed-off-by: Steven Goodwin <marquisdegeek@gmail.com>