### PR TITLE
avahi-python: Encode unicode strings as UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ltmain.sh
 missing
 py-compile
 stamp-h1
+test-driver

--- a/avahi-python/avahi/.gitignore
+++ b/avahi-python/avahi/.gitignore
@@ -1,1 +1,6 @@
+*.log
+*.pyc
+*.pyo
+*.trs
 ServiceTypeDatabase.py
+__pycache__/

--- a/avahi-python/avahi/Makefile.am
+++ b/avahi-python/avahi/Makefile.am
@@ -16,6 +16,11 @@
 # USA.
 
 EXTRA_DIST = __init__.py ServiceTypeDatabase.py.in
+EXTRA_DIST += test.py
+
+TESTS =
+TEST_EXTENSIONS = .py
+PY_LOG_COMPILER = $(PYTHON)
 
 pkglibdatadir=$(libdir)/avahi
 
@@ -54,6 +59,8 @@ avahi_PYTHON = $(avahi_SCRIPTS)
 if HAVE_PYTHON_DBUS
 
 avahi_PYTHON += __init__.py
+
+TESTS += test.py
 
 endif
 endif

--- a/avahi-python/avahi/__init__.py
+++ b/avahi-python/avahi/__init__.py
@@ -17,6 +17,8 @@
 
 # Some definitions matching those in avahi-common/defs.h
 
+import sys
+
 import dbus
 
 SERVER_INVALID, SERVER_REGISTERING, SERVER_RUNNING, SERVER_COLLISION, SERVER_FAILURE = range(0, 5)
@@ -66,6 +68,9 @@ DBUS_INTERFACE_HOST_NAME_RESOLVER = DBUS_NAME + ".HostNameResolver"
 DBUS_INTERFACE_SERVICE_RESOLVER = DBUS_NAME + ".ServiceResolver"
 DBUS_INTERFACE_RECORD_BROWSER = DBUS_NAME + ".RecordBrowser"
 
+if sys.version_info[0] >= 3:
+    unicode = str
+
 def byte_array_to_string(s):
     r = ""
     
@@ -86,12 +91,19 @@ def txt_array_to_string_array(t):
 
     return l
 
-
 def string_to_byte_array(s):
+    if isinstance(s, unicode):
+        s = s.encode('utf-8')
+
     r = []
 
     for c in s:
-        r.append(dbus.Byte(ord(c)))
+        if isinstance(c, int):
+            # Python 3: iterating over bytes yields ints
+            r.append(dbus.Byte(c))
+        else:
+            # Python 2: iterating over str yields str
+            r.append(dbus.Byte(ord(c)))
 
     return r
 
@@ -107,6 +119,12 @@ def dict_to_txt_array(txt_dict):
     l = []
 
     for k,v in txt_dict.items():
-        l.append(string_to_byte_array("%s=%s" % (k,v)))
+        if isinstance(k, unicode):
+            k = k.encode('utf-8')
+
+        if isinstance(v, unicode):
+            v = v.encode('utf-8')
+
+        l.append(string_to_byte_array(b"%s=%s" % (k,v)))
 
     return l

--- a/avahi-python/avahi/test.py
+++ b/avahi-python/avahi/test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Simon McVittie
+#
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+import os
+import os.path
+import sys
+import unittest
+from collections import OrderedDict
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+
+import avahi
+import dbus
+
+class TestUtilityMethods(unittest.TestCase):
+    def test_byte_array_to_string(self):
+        self.assertEqual(
+            avahi.byte_array_to_string([1, 2, 127, 128]),
+            '....')
+        self.assertEqual(
+            avahi.byte_array_to_string([ord('a'), ord(' '), ord('b')]),
+            'a b')
+
+    def test_txt_array_to_string_array(self):
+        self.assertEqual(
+            avahi.txt_array_to_string_array([[1, 2], [ord('a'), ord('b')]]),
+            ['..', 'ab'])
+
+    def test_string_to_byte_array(self):
+        self.assertEqual(
+            avahi.string_to_byte_array('abc'),
+            [dbus.Byte(97), dbus.Byte(98), dbus.Byte(99)])
+        self.assertIsInstance(
+            avahi.string_to_byte_array('abc')[0],
+            dbus.Byte)
+        self.assertEqual(
+            avahi.string_to_byte_array(b'\x01\xff'),
+            [dbus.Byte(0x01), dbus.Byte(0xff)])
+        self.assertEqual(
+            avahi.string_to_byte_array(u'\u00e1'),
+            [dbus.Byte(0xc3), dbus.Byte(0xa1)])
+
+    def test_string_array_to_txt_array(self):
+        self.assertEqual(
+            avahi.string_array_to_txt_array(['abc', b'\x01', u'\u00e1']),
+            [
+                [dbus.Byte(97), dbus.Byte(98), dbus.Byte(99)],
+                [dbus.Byte(0x01)],
+                [dbus.Byte(0xc3), dbus.Byte(0xa1)]])
+        self.assertIsInstance(
+            avahi.string_array_to_txt_array(['abc'])[0][0],
+            dbus.Byte)
+
+    def test_dict_to_txt_array(self):
+        self.assertEqual(
+            avahi.dict_to_txt_array(
+                OrderedDict((('a', 'abc'), ('b', b'\x01'), ('c', u'\u00e1')))),
+            [
+                [dbus.Byte(97), dbus.Byte(ord('=')), dbus.Byte(97), dbus.Byte(98), dbus.Byte(99)],
+                [dbus.Byte(98), dbus.Byte(ord('=')), dbus.Byte(0x01)],
+                [dbus.Byte(99), dbus.Byte(ord('=')), dbus.Byte(0xc3), dbus.Byte(0xa1)]])
+        self.assertIsInstance(
+            avahi.dict_to_txt_array({'a': 'abc'})[0][0],
+            dbus.Byte)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Previously, we would effectively encode anything representable in
Latin-1 as Latin-1, and crash on anything not representable in Latin-1:
    
    >>> import avahi
    >>> avahi.string_to_byte_array(u'©')
    [dbus.Byte(169)]
    >>> avahi.string_to_byte_array(u'\ufeff')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib/python2.7/dist-packages/avahi/__init__.py", line 94, in string_to_byte_array
        r.append(dbus.Byte(ord(c)))
    ValueError: Integer outside range 0-255
    
This is particularly important for Python 3, where the str type
is a Unicode string.
    
The b'' syntax for bytestrings is supported since at least Python 2.7.
    
These functions now accept either Unicode strings (Python 2 unicode,
Python 3 str), which are encoded in UTF-8, or bytestrings
(Python 2 str, Python 3 bytes) which are taken as-is.
