### PR TITLE
systemd: add basic modern security protection

### DIFF
--- a/avahi-daemon/Makefile.am
+++ b/avahi-daemon/Makefile.am
@@ -77,7 +77,8 @@ dist_pkgdata_DATA = \
 	avahi-service.dtd
 
 %.service: %.service.in
-	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' $< > $@
+	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' \
+		-e 's,@avahi_runtime_dir\@,$(avahi_runtime_dir),g' $< > $@
 
 %.socket: %.socket.in
 	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' \

--- a/avahi-daemon/avahi-daemon.service.in
+++ b/avahi-daemon/avahi-daemon.service.in
@@ -26,6 +26,24 @@ ExecStart=@sbindir@/avahi-daemon -s
 ExecReload=@sbindir@/avahi-daemon -r
 NotifyAccess=main
 
+ProtectSystem=strict
+ReadWritePaths=@avahi_runtime_dir@/avahi-daemon/
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_ROUTE AF_INET AF_INET6
+RestrictNamespaces=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+
+# Syscall block list. Debugger calls might allow unprivileged process to
+# escape chroot. Also block a few unprivileged syscalls we don't need.
+SystemCallFilter=~@debug @obsolete
+
 [Install]
 WantedBy=multi-user.target
 Also=avahi-daemon.socket


### PR DESCRIPTION
Inspired by `systemd-resolved.service`, I went through the sandboxing
section of `man systemd.exec` and added settings accordingly.  A lot of
them are described as "recommended for long-running processes".

This applies a nice standard confinement to the service as a whole.
Most of these settings are just redundant protection for the filesystem.

I included a ban on debugging (ptrace), which an attacker might try using
to escape the chroot jail.

I banned user namespaces.  Just because we can, and they're a massive
feature, and there have been security bugs in the past.

I checked through our socket() calls, so I could set
RestrictAddressFamilies.  There's a *lot* of address families used for
different things.  Avahi does not need to use AF_BLUETOOTH for example, so
let's only allow the ones we need.

I *tried* setting NoNewPrivileges, and/or BoundingCapabilities based on
caps.c.  Unfortunately it's not that simple: they cause startup to fail.
So I haven't added either of them here.