### PR TITLE
Dot on the wrong side of 'local'

### DIFF
--- a/man/avahi-browse.1.xml.in
+++ b/man/avahi-browse.1.xml.in
@@ -56,7 +56,7 @@
 		<p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
         <optdesc><p>Browse in the specified domain. If omitted
         avahi-browse will browse in the default browsing domain
-        (usually .local)</p></optdesc>
+        (usually local.)</p></optdesc>
 	  </option>
 
       <option>


### PR DESCRIPTION
The correct domain name for local queries is `local` or `local.` (second has probably better performance), but `.local` is incorrect.

Avahi throws the following error when it is used:
`avahi_service_browser_new() failed: Invalid domain name`