### PR TITLE
Migrate from intltool to gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-intltool-extract.in
-intltool-merge.in
-intltool-update.in
 *.tar.gz
 doxygen
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ before_install:
   - sudo apt-get build-dep avahi avahi-sharp
   - sudo apt-get install python-gi-dev gir1.2-gtk-3.0
   - sudo apt-get install mono-mcs qtbase5-dev
-  - sudo apt-get install intltool
   - sudo apt-get install libevent-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 git:
   quiet: true
 language: c
+dist: xenial
 compiler:
   - gcc
   - clang

--- a/Makefile.am
+++ b/Makefile.am
@@ -260,6 +260,3 @@ homepage:
 	$(MAKE) doxygen-run
 	ssh tango rm -rf www/avahi.org/tree/download/doxygen
 	scp -r doxygen/html tango:www/avahi.org/tree/download/doxygen
-
-DISTCLEANFILES = \
-	po/.intltool-merge-cache

--- a/autogen.sh
+++ b/autogen.sh
@@ -70,7 +70,6 @@ else
 
     test "x$LIBTOOLIZE" = "x" && LIBTOOLIZE=libtoolize
 
-    intltoolize --copy --force --automake
     "$LIBTOOLIZE" -c --force
     run_versioned aclocal "$AM_VERSION" -I common
     run_versioned autoconf "$AC_VERSION" -Wall

--- a/avahi-python/avahi-discover/Makefile.am
+++ b/avahi-python/avahi-discover/Makefile.am
@@ -34,18 +34,19 @@ if HAVE_GDBM
 pythonscripts += \
 	avahi-discover
 desktop_DATA += avahi-discover.desktop
-@INTLTOOL_DESKTOP_RULE@
 endif
 
 if HAVE_DBM
 pythonscripts += \
 	avahi-discover
 desktop_DATA += avahi-discover.desktop
-@INTLTOOL_DESKTOP_RULE@
 endif
 
 avahi-discover.desktop.in: avahi-discover.desktop.in.in
 	$(AM_V_GEN)sed -e 's,@bindir\@,$(bindir),g' $< > $@
+
+avahi-discover.desktop: avahi-discover.desktop.in
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 avahi-discover: avahi-discover.py
 	$(AM_V_GEN)sed -e 's,@PYTHON\@,$(PYTHON),g' \

--- a/avahi-python/avahi-discover/avahi-discover.desktop.in.in
+++ b/avahi-python/avahi-discover/avahi-discover.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
-_Name=Avahi Zeroconf Browser
-_Comment=Browse for Zeroconf services available on your network
+Name=Avahi Zeroconf Browser
+Comment=Browse for Zeroconf services available on your network
 Exec=@bindir@/avahi-discover
 Terminal=false
 Type=Application

--- a/avahi-ui/Makefile.am
+++ b/avahi-ui/Makefile.am
@@ -80,7 +80,6 @@ endif
 
 bin_PROGRAMS = bssh
 desktop_DATA += bssh.desktop bvnc.desktop
-@INTLTOOL_DESKTOP_RULE@
 
 bssh_SOURCES = bssh.c
 
@@ -101,13 +100,17 @@ install-exec-local:
 bssh.desktop.in: bssh.desktop.in.in
 	$(AM_V_GEN)sed -e 's,@bindir\@,$(bindir),g' $< > $@
 
+bssh.desktop: bssh.desktop.in
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
+
 bvnc.desktop.in: bvnc.desktop.in.in
 	$(AM_V_GEN)sed -e 's,@bindir\@,$(bindir),g' $< > $@
+
+bvnc.desktop: bvnc.desktop.in
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 endif # HAVE_GLIB
 endif
 endif
-
-@INTLTOOL_DESKTOP_RULE@
 
 CLEANFILES = $(desktop_DATA) $(desktop_DATA_in)

--- a/avahi-ui/bssh.desktop.in.in
+++ b/avahi-ui/bssh.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
-_Name=Avahi SSH Server Browser
-_Comment=Browse for Zeroconf-enabled SSH Servers
+Name=Avahi SSH Server Browser
+Comment=Browse for Zeroconf-enabled SSH Servers
 Exec=@bindir@/bssh
 Terminal=false
 Type=Application

--- a/avahi-ui/bvnc.desktop.in.in
+++ b/avahi-ui/bvnc.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
-_Name=Avahi VNC Server Browser
-_Comment=Browse for Zeroconf-enabled VNC Servers
+Name=Avahi VNC Server Browser
+Comment=Browse for Zeroconf-enabled VNC Servers
 Exec=@bindir@/bvnc
 Terminal=false
 Type=Application

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,4 +1,3 @@
-intltool.m4
 ChangeLog
 gettext.m4
 iconv.m4

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -16,6 +16,6 @@
 # USA.
 
 EXTRA_DIST = gettext.m4 iconv.m4 lib-ld.m4 lib-link.m4 lib-prefix.m4 nls.m4 po.m4 progtest.m4 \
-    doxygen.m4 \
+	doxygen.m4 \
 	doxygen.mk \
 	python.m4

--- a/configure.ac
+++ b/configure.ac
@@ -415,11 +415,11 @@ if test "x$have_kqueue" = "xyes" ; then
     AC_DEFINE([HAVE_KQUEUE], 1, [Enable BSD kqueue() usage])
 fi
 
-IT_PROG_INTLTOOL([0.35.0])
 GETTEXT_PACKAGE=avahi
 AC_SUBST([GETTEXT_PACKAGE])
 AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[Gettext package])
-AM_GLIB_GNU_GETTEXT
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT([external])
 
 avahilocaledir='${prefix}/${DATADIRNAME}/locale'
 AC_SUBST(avahilocaledir)

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,5 +1,4 @@
 *.pot
-.intltool-merge-cache
 ChangeLog
 Makefile
 Makefile.in

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,78 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = $(PACKAGE)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --add-comments
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = The Avahi developers.
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS = https://github.com/lathiat/avahi/issues
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = yes
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,6 @@
 # List of source files which contain translatable strings.
 avahi-common/error.c
-[type: gettext/glade]avahi-discover-standalone/avahi-discover.ui
+avahi-discover-standalone/avahi-discover.ui
 avahi-python/avahi-discover/avahi-discover.desktop.in.in
 avahi-python/avahi-discover/avahi-discover.py
 avahi-ui/avahi-ui.c


### PR DESCRIPTION
This patch changes the build scripts to use `gettext` for i18n strings extraction and merging in place of `intltool`. This allow dropping the dependency to `intltool`.

Fixes: https://github.com/lathiat/avahi/issues/217
Closes: https://github.com/lathiat/avahi/pull/22