### PR TITLE
use DBusGMainLoop instead of Importing dbus.glib to use the GLib main…

### DIFF
--- a/avahi-python/avahi-discover/avahi-discover.py
+++ b/avahi-python/avahi-discover/avahi-discover.py
@@ -42,7 +42,8 @@ except Exception as e:
 ##
 try:
     from dbus import DBusException
-    import dbus.glib
+    from dbus.mainloop.glib import DBusGMainLoop
+    DBusGMainLoop(set_as_default=True)
 except ImportError as e:
     pass
 


### PR DESCRIPTION
… loop

fixes this warning when running avahi-discover:
```
/usr/bin/avahi-discover:45: DeprecationWarning: Importing dbus.glib to use the GLib main loop with dbus-python is deprecated.
Instead, use this sequence:

    from dbus.mainloop.glib import DBusGMainLoop

    DBusGMainLoop(set_as_default=True)

  import dbus.glib
```