### PR TITLE
Fix issue 117 "Spurious name conflicts" in case of reflector

### DIFF
--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -542,15 +542,9 @@ static void reflect_query(AvahiServer *s, AvahiInterface *i, AvahiKey *k) {
         return;
 
     for (j = s->monitor->interfaces; j; j = j->interface_next)
-        if (j != i && (s->config.reflect_ipv || j->protocol == i->protocol)) {
-            /* Post the query to other networks */
+        if (j != i && (s->config.reflect_ipv || j->protocol == i->protocol))
             avahi_interface_post_query(j, k, 1, NULL);
 
-            /* Reply from caches of other network. This is needed to
-             * "work around" known answer suppression. */
-
-            avahi_cache_walk(j->cache, k, reflect_cache_walk_callback, s);
-        }
 }
 
 static void reflect_probe(AvahiServer *s, AvahiInterface *i, AvahiRecord *r) {


### PR DESCRIPTION
The reflector sends back the whole cache when it receives a query.

As a result, a machine named `somemachine.local` may receive its own cached information, think its name is duplicate (used by another machine), and change it unexpectedly to `somemachine-2.local` (more detail on issue #117).

This PR removes an old workaround supposed to fix known answer suppression (part of commit 4ff0807c04fcc239de52a793bceb88e7f3408f3f from 2005). However, I think the workaround was worse than the problem itself: at my place, this makes the reflector unusable.

It **does not** fix issue 117 in the general case.