### PR TITLE
Fix a crash when txt records has an empty value

### DIFF
--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -627,8 +627,13 @@ static void XMLCALL xml_end(void *data, AVAHI_GCC_UNUSED const char *el) {
 
                 switch (u->txt_type) {
                     case TXT_RECORD_VALUE_TEXT:
-                        value_buf_len = strlen(u->buf);
-                        value_buf = (uint8_t*)u->buf;
+                        if (u->buf != NULL) {
+                            value_buf_len = strlen(u->buf);
+                            value_buf = (uint8_t*)u->buf;
+                        } else {
+                            value_buf_len = 0;
+                            value_buf = (uint8_t*)"";
+                        }
                         break;
 
                     case TXT_RECORD_VALUE_BINARY_HEX:


### PR DESCRIPTION
That's a regression that came with 3b067e06b274 ("Add support for
binary values in TXT records in service files"), we dropped the NULL
check for the strlen call. Other txt record types already check for
NULL value in the decode functions.

Reported at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=882386