### PR TITLE
Replace deprecated python `has_key` function with `in` syntax

### DIFF
--- a/avahi-python/avahi-discover/avahi-discover.py
+++ b/avahi-python/avahi-discover/avahi-discover.py
@@ -210,10 +210,10 @@ class Main_window:
             self.new_service_type(interface, protocol, self.stype, domain)
 
     def new_domain(self,interface, protocol, domain, flags):
-        if self.zc_ifaces.has_key((interface,protocol)) == False:
+        if ((interface,protocol) in self.zc_ifaces) == False:
             ifn = self.get_interface_name(interface, protocol)
             self.zc_ifaces[(interface,protocol)] = self.insert_row(self.treemodel, None, ifn,None,interface,protocol,None,domain)
-        if self.zc_domains.has_key((interface,protocol,domain)) == False:
+        if ((interface,protocol,domain) in self.zc_domains) == False:
             self.zc_domains[(interface,protocol,domain)] = self.insert_row(self.treemodel, self.zc_ifaces[(interface,protocol)], domain,None,interface,protocol,None,domain)
         if domain != "local":
             self.browse_domain(interface, protocol, domain)


### PR DESCRIPTION
`dict.has_key()` has been deprecated in python3, as per the release docs: https://docs.python.org/3.0/whatsnew/3.0.html#builtins

This pull request updates uses of `has_key` to use python's `in` syntax, which I've checked is backwards compatible with python 2.7.

Note that I needed this change because I'm building on arch linux with this PKGBUILD: https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/avahi

However AFAICT this will fix the following exception for anyone with python3 as the default on their system:
```
ERROR:dbus.connection:Exception in handler for D-Bus signal:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/dbus/connection.py", line 230, in maybe_handle_message
    self._handler(*args, **kwargs)
  File "/usr/bin/avahi-discover", line 212, in new_domain
    if self.zc_ifaces.has_key((interface,protocol)) == False:
AttributeError: 'dict' object has no attribute 'has_key'
```