### PR TITLE
pkgconfig: Match the first three parameters

### DIFF
--- a/avahi-client.pc.in
+++ b/avahi-client.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-client

--- a/avahi-compat-howl.pc.in
+++ b/avahi-compat-howl.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include/avahi-compat-howl/
 
 Name: avahi-compat-howl

--- a/avahi-compat-libdns_sd.pc.in
+++ b/avahi-compat-libdns_sd.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include/avahi-compat-libdns_sd/
 
 Name: avahi-compat-libdns_sd

--- a/avahi-core.pc.in
+++ b/avahi-core.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-core

--- a/avahi-glib.pc.in
+++ b/avahi-glib.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-glib

--- a/avahi-gobject.pc.in
+++ b/avahi-gobject.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-gobject

--- a/avahi-libevent.pc.in
+++ b/avahi-libevent.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-libevent

--- a/avahi-qt3.pc.in
+++ b/avahi-qt3.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-qt3

--- a/avahi-qt4.pc.in
+++ b/avahi-qt4.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-qt4

--- a/avahi-qt5.pc.in
+++ b/avahi-qt5.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-qt5

--- a/avahi-sharp.pc.in
+++ b/avahi-sharp.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=@libdir@
+libdir=${exec_prefix}/@libdir@
 
 Name: avahi-sharp
 Description: Mono bindings for the Avahi mDNS/DNS-SD stack

--- a/avahi-ui-gtk3.pc.in
+++ b/avahi-ui-gtk3.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-ui

--- a/avahi-ui-sharp.pc.in
+++ b/avahi-ui-sharp.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=@libdir@
+libdir=${exec_prefix}/@libdir@
 
 Name: avahi-ui-sharp
 Description: Mono bindings for the Avahi mDNS/DNS-SD stack

--- a/avahi-ui.pc.in
+++ b/avahi-ui.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=@libdir@
+exec_prefix=@prefix@
+libdir=${exec_prefix}/@libdir@
 includedir=${prefix}/include
 
 Name: avahi-ui


### PR DESCRIPTION
For consistency between projects. Might also fix several cross compilation
cases.

Signed-off-by: Rosen Penev <rosenp@gmail.com>