### PR TITLE
Protect against NULL-pointer-deference with malformed txt records

### DIFF
--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -627,8 +627,8 @@ static void XMLCALL xml_end(void *data, AVAHI_GCC_UNUSED const char *el) {
 
                 switch (u->txt_type) {
                     case TXT_RECORD_VALUE_TEXT:
-                        value_buf_len = strlen(u->buf);
-                        value_buf = (uint8_t*)u->buf;
+                        value_buf_len = u->buf ? strlen(u->buf) : 0;
+                        value_buf = u->buf ? (uint8_t*)u->buf : "";
                         break;
 
                     case TXT_RECORD_VALUE_BINARY_HEX:


### PR DESCRIPTION
If the txt record is malformed, or is empty ("foo="), then we can hit
a NULL-pointer-de-reference.

Fixes: 3b067e06b274c60a9745bb45467e2eb0d9f3f0be

Signed-off-by: Mark Marshall <mark.marshall@omicronenergy.com>