### PR TITLE
Avoid strlen(NULL) crash on some txt-records

### DIFF
--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -627,7 +627,7 @@ static void XMLCALL xml_end(void *data, AVAHI_GCC_UNUSED const char *el) {
 
                 switch (u->txt_type) {
                     case TXT_RECORD_VALUE_TEXT:
-                        value_buf_len = strlen(u->buf);
+                        value_buf_len = (u->buf ? strlen(u->buf) : 0);
                         value_buf = (uint8_t*)u->buf;
                         break;
 


### PR DESCRIPTION
A record with only key= and empty value causes a crash, eg.
<txt-record>note=</txt-record>

http://bugs.debian.org/947891