### PR TITLE
Do not cache responses generated locally

### DIFF
--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -676,9 +676,11 @@ static void handle_response_packet(AvahiServer *s, AvahiDnsPacket *p, AvahiInter
         if (!avahi_key_is_pattern(record->key)) {
 
             if (handle_conflict(s, i, record, cache_flush)) {
-                if (!from_local_iface && !avahi_record_is_link_local_address(record))
-                    reflect_response(s, i, record, cache_flush);
-                avahi_cache_update(i->cache, record, cache_flush, a);
+                if (!from_local_iface) {
+                    if (!avahi_record_is_link_local_address(record))
+                        reflect_response(s, i, record, cache_flush);
+                    avahi_cache_update(i->cache, record, cache_flush, a);
+                }
                 avahi_response_scheduler_incoming(i->response_scheduler, record, cache_flush);
             }
         }


### PR DESCRIPTION
Consider the following setup:
```
          +---------+               +--------+
          |  host1  |               | host2  |
          |         |               |        |
 ---------+ eth1    |               |        |
          |         |               |        |
          |    eth0 +---------------+ eth0   |
          +---------+               +--------+
```
where `host1` is set as a reflector.

Without this PR, the Resource Records responses coming from `host2` are stored on two caches: on the cache associated with `eth0` (correct), and on the cache associated with `eth1` (wrong).

The RR responses associated with one interface should not be cached on the other interface in the case of a reflector. Otherwise, when `host2` is probing for duplicates (for example after bringing `eth0` down and then up again), it would get old, and possibly wrong information from the cache associated to `eth1` on the reflector, and wrongly conclude to a name conflict and rename itself (aka spurious name conflict).

This PR calls `avahi_cache_update()` only if `from_local_interface` is not true, thus avoiding the caching on the wrong interface.
