### PR TITLE
fix requires in pc file

### DIFF
--- a/avahi-libevent.pc.in
+++ b/avahi-libevent.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: avahi-libevent
 Description: Avahi Multicast DNS Responder (libevent Support)
 Version: @PACKAGE_VERSION@
-Requires: libevent-2.1.5
+Requires: libevent >= 2.1.5
 Libs: -L${libdir} -lavahi-libevent
 Cflags: -D_REENTRANT -I${includedir}


### PR DESCRIPTION
When you build rpm with avahi-0.8 and libevent enabled then you will end up in broken rpm requires on non-existing "pkgconfig(libevent-2.1.5)"

```
DEBUG util.py:587:  cooker_main_release                              14 kB/s | 2.5 kB     00:00    
DEBUG util.py:587:  cooker_main_release                             1.5 MB/s |  12 MB     00:08    
DEBUG util.py:587:  cooker_main_updates                              21 kB/s | 1.5 kB     00:00    
DEBUG util.py:585:  BUILDSTDERR: Error: 
DEBUG util.py:585:  BUILDSTDERR:  Problem: conflicting requests
DEBUG util.py:585:  BUILDSTDERR:   - nothing provides pkgconfig(libevent-2.1.5) needed by lib64avahi-libevent-devel-0.8-1.x86_64
DEBUG util.py:587:  (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
DEBUG util.py:734:  Child return code was: 1
DEBUG util.py:323:  kill orphans
```