### PR TITLE
Fix bytestring decoding for proper display

### DIFF
--- a/avahi-python/avahi-discover/avahi-discover.py
+++ b/avahi-python/avahi-discover/avahi-discover.py
@@ -238,12 +238,15 @@ class Main_window:
                 txts+="<b>" + _("TXT") + " <i>%s</i></b> = %s\n" % (k,v)
         else:
             txts = "<b>" + _("TXT Data:") + "</b> <i>" + _("empty") + "</i>"
+        
+        txts = txts.decode("utf-8")
 
         infos = "<b>" + _("Service Type:") + "</b> %s\n"
         infos += "<b>" + _("Service Name:") + "</b> %s\n"
         infos += "<b>" + _("Domain Name:") + "</b> %s\n"
         infos += "<b>" + _("Interface:") + "</b> %s %s\n"
         infos += "<b>" + _("Address:") + "</b> %s/%s:%i\n%s"
+        infos = infos.decode("utf-8")
         infos = infos % (stype, name, domain, self.siocgifname(interface), self.protoname(protocol), host, address, port, txts.strip())
         self.info_label.set_markup(infos)
 


### PR DESCRIPTION
On a Debian system with `fr_CA.UTF-8` locale, I got UnicodeDecodeErrors when trying to select any item in the tree view shown by avahi-discover.

I found out that the translated strings use non-breaking spaces before punctuation, but these strings are bytestrings rather than text (unicode) strings, which causes line 247/250 to fail (bytes-text mixing in Python leading to implicit conversion to ASCII which fails to handle `\xC2\xA0`).

A proper fix would be to use `ugettext` (would also prepare to switch to Python 3, where gettext works in unicode), but it seems that my version of `gettext` module doesn’t have it, so this is a workaround instead.



fixes #158
