### PR TITLE
Feature: Allow specifying interface visibility when using reflector

### DIFF
--- a/avahi-core/core.h
+++ b/avahi-core/core.h
@@ -31,6 +31,7 @@ typedef struct AvahiServer AvahiServer;
 #include <avahi-common/watch.h>
 #include <avahi-common/timeval.h>
 #include <avahi-core/rr.h>
+#include <avahi-core/hashmap.h>
 
 AVAHI_C_DECL_BEGIN
 
@@ -57,6 +58,7 @@ typedef struct AvahiServerConfig {
     int enable_reflector;             /**< Reflect incoming mDNS traffic to all local networks. This allows mDNS based network browsing beyond ethernet borders */
     int reflect_ipv;                  /**< if enable_reflector is 1, enable/disable reflecting between IPv4 and IPv6 */
     AvahiStringList *reflect_filters;  /**< if enable_reflector is 1, will only add services containing one of these strings */
+    AvahiHashmap *reflect_interfaces_visibility; /**< If enable_reflector is 1, specify visibility of services on an interface to other interfaces */
     int add_service_cookie;           /**< Add magic service cookie to all locally generated records implicitly */
     int enable_wide_area;             /**< Enable wide area support */
     AvahiAddress wide_area_servers[AVAHI_WIDE_AREA_SERVERS_MAX]; /** Unicast DNS server to use for wide area lookup */

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -1426,10 +1426,15 @@ AvahiServer *avahi_server_new(const AvahiPoll *poll_api, const AvahiServerConfig
 
     s->poll_api = poll_api;
 
-    if (sc)
-        avahi_server_config_copy(&s->config, sc);
-    else
-        avahi_server_config_init(&s->config);
+    if (sc) {
+        if (!avahi_server_config_copy(&s->config, sc)) {
+            *error = AVAHI_ERR_NO_MEMORY;
+            return NULL;
+        }
+    } else if (!avahi_server_config_init(&s->config)) {
+        *error = AVAHI_ERR_NO_MEMORY;
+        return NULL;
+    }
 
     if ((e = setup_sockets(s)) < 0) {
         if (error)

--- a/avahi-daemon/avahi-daemon.conf
+++ b/avahi-daemon/avahi-daemon.conf
@@ -58,6 +58,9 @@ publish-workstation=no
 #enable-reflector=no
 #reflect-ipv=no
 #reflect-filters=_airplay._tcp.local,_raop._tcp.local
+#reflect-interface-visibility:eth0.main=!
+#reflect-interface-visibility:eth0.guest=eth0.main
+#reflect-interface-visibility:eth0.iot=eth0.main,eth0.guest
 
 [rlimits]
 #rlimit-as=

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -337,6 +337,20 @@
       services.</p>
 
     </option>
+
+    <option>
+      <p><opt>reflect-interface-visibility:<arg>source-interface</arg>=</opt>
+      Specify the visibility of an interface to a set of other
+      interfaces. Each interface listed will be able to participate
+      in reflection of services with the source interface. The
+      default is to allow reflection with all interfaces. If an
+      empty value or "!" is given, no services from the interface
+      will be reflected to any other interface (but it will still
+      receive reflections from other interfaces, unless prohibited
+      by their configuration). Conversely, giving a "*" value
+      allows reflection to all interfaces (same as the default).</p>
+    </option>
+
   </section>
 
   <section name="Section [rlimits]">


### PR DESCRIPTION
Adds the configuration option **reflect-interface-visibility:*source-interface*=** with the ability to specify the visibility of an interface to a set of other interfaces. Each interface listed will be able to participate in reflection of services with the source interface. The default is to allow reflection with all interfaces.

If an empty value or `!` is given, no services from the interface will be reflected to any other interface (but it will still receive reflections from other interfaces, unless prohibited by their configuration). Conversely, giving a `*` value allows reflection to all interfaces (same as the default).

**Example of use:**

Say you have three VLAN interfaces configured: `eth0.iot`, `eth0.guest` and `eth0.main`. You want to make `iot` services visible to `guest` and `main`, `guest` services visible to `main`, and any `main` services private. Adding the following three lines to the reflector configuration would accomplish that:

```
reflect-interface-visibility:eth0.main=!
reflect-interface-visibility:eth0.guest=eth0.main
reflect-interface-visibility:eth0.iot=eth0.main,eth0.guest
```

This can also be used with the **reflect-filter=** configuration to further tune what services are globally reflected (a per-interface filter option would make it even more flexible though).

---

I'm currently using the feature as a part of my local VLAN setup, and it appears to work well from what I have seen so far. It is still new though and would likely benefit from a few more eyeballs on it. If you find this a useful feature I would wery much like for it, or some version of it, to become a part of upstream at some point.