### PR TITLE
Include build-db in tarball releases

### DIFF
--- a/service-type-database/Makefile.am
+++ b/service-type-database/Makefile.am
@@ -28,7 +28,7 @@ dist_noinst_SCRIPTS=build-db
 pkglibdata_DATA+=service-types.db
 
 service-types.db: service-types
-	$(AM_V_GEN)$(PYTHON) build-db $< $@.coming && \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/build-db $< $@.coming && \
 	mv $@.coming $@
 
 CLEANFILES = service-types.db
@@ -44,7 +44,7 @@ service-types.db.pag: service-types.db
 service-types.db.dir: service-types.db
 	$(AM_V_GEN)mv service-types.db.coming.dir service-types.db.dir
 service-types.db: service-types build-db
-	$(AM_V_GEN)$(PYTHON) build-db $< $@.coming && \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/build-db $< $@.coming && \
 	if test -f "$@.coming"; then mv $@.coming $@; fi
 
 CLEANFILES = service-types.db*

--- a/service-type-database/Makefile.am
+++ b/service-type-database/Makefile.am
@@ -24,7 +24,7 @@ pkglibdata_DATA=
 if HAVE_PYTHON
 if HAVE_GDBM
 
-noinst_SCRIPTS=build-db
+dist_noinst_SCRIPTS=build-db
 pkglibdata_DATA+=service-types.db
 
 service-types.db: service-types
@@ -36,7 +36,7 @@ CLEANFILES = service-types.db
 endif
 if HAVE_DBM
 
-noinst_SCRIPTS=build-db
+dist_noinst_SCRIPTS=build-db
 pkglibdata_DATA+=service-types.db.pag service-types.db.dir
 
 service-types.db.pag: service-types.db


### PR DESCRIPTION
* build: Include build-db in tarball releases
    
    SCRIPTS are not included in tarballs by default, because they might
    be generated from a template. This one isn't, so use the dist_
    prefix to distribute it.
    
    Resolves: https://github.com/lathiat/avahi/issues/277

* build: Look for build-db in the srcdir
    
    Otherwise, srcdir != builddir builds (and hence distcheck) will fail.

---

Tested with:

```
make -j5 DISTCHECK_CONFIGURE_FLAGS="--disable-libevent --disable-qt5 --disable-mono --with-systemdsystemunitdir='\$\$dc_install_base/\${systemdsystemunitdir}'" distcheck
```

(I haven't tried distcheck with libevent, Mono or Qt since I don't currently have those installed.)