### PR TITLE
function lookup_find() doesn't find the correct AvahiSRBLoockup instance

### DIFF
--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -169,7 +169,7 @@ static AvahiSRBLookup *lookup_find(
     for (l = b->lookups; l; l = l->lookups_next) {
 
         if ((l->interface == AVAHI_IF_UNSPEC || l->interface == interface) &&
-            (l->interface == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
+            (l->protocol == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
             l->flags == flags &&
             avahi_key_equal(l->key, key))
 


### PR DESCRIPTION
... in case the protocol member equals AVAHI_PROTO_UNSPEC. I'm note sure about the side effects of my fix, but it somehow looks correct to me.