### PR TITLE
Load distribution name from /etc/os-release

### DIFF
--- a/avahi-core/domain-util.c
+++ b/avahi-core/domain-util.c
@@ -93,8 +93,13 @@ static int load_lsb_distrib_id(char *ret_s, size_t size) {
     return load_id(ret_s, size, "/etc/lsb-release", "DISTRIB_ID=");
 }
 
-static int load_os_id(char *ret_s, size_t size) {
-    return load_id(ret_s, size, "/etc/os-release", "ID=");
+static int load_os_hostname(char *ret_s, size_t size) {
+    int r;
+
+    r = load_id(ret_s, size, "/etc/os-release", "DEFAULT_HOSTNAME=");
+    if (r < 0)
+        r = load_id(ret_s, size, "/etc/os-release", "ID=");
+    return r;
 }
 #endif
 
@@ -119,7 +124,7 @@ char *avahi_get_host_name(char *ret_s, size_t size) {
 #ifdef __linux__
 
         /* Try os-release or LSB distribution name first */
-        if (load_os_id(ret_s, size) >= 0 || load_lsb_distrib_id(ret_s, size) >= 0) {
+        if (load_os_hostname(ret_s, size) >= 0 || load_lsb_distrib_id(ret_s, size) >= 0) {
             strip_bad_chars(ret_s);
             avahi_strdown(ret_s);
         }

--- a/avahi-core/domain-util.c
+++ b/avahi-core/domain-util.c
@@ -53,6 +53,7 @@ static void strip_bad_chars(char *s) {
 #ifdef __linux__
 static int load_id(char *ret_s, size_t size, const char *filename, const char *field) {
     FILE *f;
+    size_t flen;
 
     assert(ret_s);
     assert(size > 0);
@@ -63,16 +64,18 @@ static int load_id(char *ret_s, size_t size, const char *filename, const char *f
     if (!(f = fopen(filename, "r")))
         return -1;
 
+    flen = strlen(field);
+
     while (!feof(f)) {
         char ln[256], *p;
 
         if (!fgets(ln, sizeof(ln), f))
             break;
 
-        if (strncmp(ln, field, strlen(field)))
+        if (strncmp(ln, field, flen))
             continue;
 
-        p = ln + strlen(field);
+        p = ln + flen;
         p += strspn(p, "\"");
         p[strcspn(p, "\"")] = 0;
 


### PR DESCRIPTION
/etc/lsb-release really isn't used much since systemd started exporting
/etc/os-release. Reuse existing lsb-release parsing code to parse
os-release. This should allow avahi to call hosts without a hostname by
their distribution name, as requested in:
https://bugzilla.redhat.com/show_bug.cgi?id=1392924