### PR TITLE
Logic for p2p on tunnels incorrectly requires IFF_MULTICAST (#305)

### DIFF
--- a/avahi-core/iface-linux.c
+++ b/avahi-core/iface-linux.c
@@ -105,8 +105,8 @@ static void netlink_callback(AvahiNetlink *nl, struct nlmsghdr *n, void* userdat
             (ifinfomsg->ifi_flags & IFF_UP) &&
             (!m->server->config.use_iff_running || (ifinfomsg->ifi_flags & IFF_RUNNING)) &&
             ((ifinfomsg->ifi_flags & IFF_LOOPBACK) ||
-             (ifinfomsg->ifi_flags & IFF_MULTICAST)) &&
-            (m->server->config.allow_point_to_point || !(ifinfomsg->ifi_flags & IFF_POINTOPOINT));
+             (ifinfomsg->ifi_flags & IFF_MULTICAST) ||
+             ((ifinfomsg->ifi_flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
 
         /* Handle interface attributes */
         l = NLMSG_PAYLOAD(n, sizeof(struct ifinfomsg));

--- a/avahi-core/iface-pfroute.c
+++ b/avahi-core/iface-pfroute.c
@@ -81,8 +81,8 @@ static void rtm_info(struct rt_msghdr *rtm, AvahiInterfaceMonitor *m)
     (ifm->ifm_flags & IFF_UP) &&
     (!m->server->config.use_iff_running || (ifm->ifm_flags & IFF_RUNNING)) &&
     ((ifm->ifm_flags & IFF_LOOPBACK) ||
-     (ifm->ifm_flags & IFF_MULTICAST)) &&
-    (m->server->config.allow_point_to_point || !(ifm->ifm_flags & IFF_POINTOPOINT));
+     (ifm->ifm_flags & IFF_MULTICAST) ||
+      ((ifm->ifm_flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
 
   avahi_free(hw->name);
   hw->name = avahi_strndup(sdl->sdl_data, sdl->sdl_nlen);
@@ -428,8 +428,8 @@ static void if_add_interface(struct lifreq *lifreq, AvahiInterfaceMonitor *m, in
             (flags & IFF_UP) &&
             (!m->server->config.use_iff_running || (flags & IFF_RUNNING)) &&
             ((flags & IFF_LOOPBACK) ||
-            (flags & IFF_MULTICAST)) &&
-            (m->server->config.allow_point_to_point || !(flags & IFF_POINTOPOINT));
+             (flags & IFF_MULTICAST) ||
+              ((flags & IFF_POINTOPOINT) && m->server->config.allow_point_to_point));
         hw->name = avahi_strdup(lifreq->lifr_name);
         hw->mtu = mtu;
         /* TODO get mac address */


### PR DESCRIPTION
Point-to-point interfaces don't have MULTICAST set on them, since anything other than a unicast is a meaningless concept.

I've back ported this fix to CentOS 8 Stream and avahi-0.7 and it works fine.

Addresses issue #305.
