### PR TITLE
Implement org.freedesktop.Properties

### DIFF
--- a/avahi-daemon/dbus-util.c
+++ b/avahi-daemon/dbus-util.c
@@ -66,6 +66,54 @@ DBusHandlerResult avahi_dbus_respond_error(DBusConnection *c, DBusMessage *m, in
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
+DBusHandlerResult avahi_dbus_respond_unknown_property_error(DBusConnection *c, DBusMessage *m) {
+    DBusMessage *reply;
+
+    reply = dbus_message_new_error(m, DBUS_ERROR_UNKNOWN_PROPERTY, "Unknown property");
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_invalid_signature_error(DBusConnection *c, DBusMessage *m) {
+    DBusMessage *reply;
+
+    reply = dbus_message_new_error(m, DBUS_ERROR_INVALID_SIGNATURE, "Invalid signature");
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_read_only_property_error(DBusConnection *c, DBusMessage *m) {
+    DBusMessage *reply;
+
+    reply = dbus_message_new_error(m, DBUS_ERROR_PROPERTY_READ_ONLY, "Property is read-only");
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
 DBusHandlerResult avahi_dbus_respond_string(DBusConnection *c, DBusMessage *m, const char *text) {
     DBusMessage *reply;
 
@@ -164,6 +212,90 @@ DBusHandlerResult avahi_dbus_respond_path(DBusConnection *c, DBusMessage *m, con
     }
 
     dbus_message_append_args(reply, DBUS_TYPE_OBJECT_PATH, &path, DBUS_TYPE_INVALID);
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_variant_string(DBusConnection *c, DBusMessage *m, const char *text) {
+    DBusMessage *reply;
+    DBusMessageIter iter, value;
+
+    reply = dbus_message_new_method_return(m);
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_message_iter_init_append(reply, &iter);
+    dbus_message_iter_open_container(&iter, DBUS_TYPE_VARIANT, "s", &value);
+    dbus_message_iter_append_basic(&value, DBUS_TYPE_STRING, &text);
+    dbus_message_iter_close_container(&iter, &value);
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_variant_int32(DBusConnection *c, DBusMessage *m, int32_t i) {
+    DBusMessage *reply;
+    DBusMessageIter iter, value;
+
+    reply = dbus_message_new_method_return(m);
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_message_iter_init_append(reply, &iter);
+    dbus_message_iter_open_container(&iter, DBUS_TYPE_VARIANT, "i", &value);
+    dbus_message_iter_append_basic(&value, DBUS_TYPE_INT32, &i);
+    dbus_message_iter_close_container(&iter, &value);
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_variant_uint32(DBusConnection *c, DBusMessage *m, uint32_t u) {
+    DBusMessage *reply;
+    DBusMessageIter iter, value;
+
+    reply = dbus_message_new_method_return(m);
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_message_iter_init_append(reply, &iter);
+    dbus_message_iter_open_container(&iter, DBUS_TYPE_VARIANT, "u", &value);
+    dbus_message_iter_append_basic(&value, DBUS_TYPE_UINT32, &u);
+    dbus_message_iter_close_container(&iter, &value);
+    dbus_connection_send(c, reply, NULL);
+    dbus_message_unref(reply);
+
+    return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult avahi_dbus_respond_variant_boolean(DBusConnection *c, DBusMessage *m, int b) {
+    DBusMessage *reply;
+    DBusMessageIter iter, value;
+
+    reply = dbus_message_new_method_return(m);
+
+    if (!reply) {
+        avahi_log_error("Failed allocate message");
+        return DBUS_HANDLER_RESULT_NEED_MEMORY;
+    }
+
+    dbus_message_iter_init_append(reply, &iter);
+    dbus_message_iter_open_container(&iter, DBUS_TYPE_VARIANT, "b", &value);
+    dbus_message_iter_append_basic(&value, DBUS_TYPE_BOOLEAN, &b);
+    dbus_message_iter_close_container(&iter, &value);
     dbus_connection_send(c, reply, NULL);
     dbus_message_unref(reply);
 

--- a/avahi-daemon/dbus-util.h
+++ b/avahi-daemon/dbus-util.h
@@ -30,12 +30,19 @@
 #include "dbus-internal.h"
 
 DBusHandlerResult avahi_dbus_respond_error(DBusConnection *c, DBusMessage *m, int error, const char *text);
+DBusHandlerResult avahi_dbus_respond_unknown_property_error(DBusConnection *c, DBusMessage *m);
+DBusHandlerResult avahi_dbus_respond_read_only_property_error(DBusConnection *c, DBusMessage *m);
+DBusHandlerResult avahi_dbus_respond_invalid_signature_error(DBusConnection *c, DBusMessage *m);
 DBusHandlerResult avahi_dbus_respond_string(DBusConnection *c, DBusMessage *m, const char *text);
 DBusHandlerResult avahi_dbus_respond_int32(DBusConnection *c, DBusMessage *m, int32_t i);
 DBusHandlerResult avahi_dbus_respond_uint32(DBusConnection *c, DBusMessage *m, uint32_t u);
 DBusHandlerResult avahi_dbus_respond_boolean(DBusConnection *c, DBusMessage *m, int b);
 DBusHandlerResult avahi_dbus_respond_ok(DBusConnection *c, DBusMessage *m);
 DBusHandlerResult avahi_dbus_respond_path(DBusConnection *c, DBusMessage *m, const char *path);
+DBusHandlerResult avahi_dbus_respond_variant_string(DBusConnection *c, DBusMessage *m, const char *text);
+DBusHandlerResult avahi_dbus_respond_variant_int32(DBusConnection *c, DBusMessage *m, int32_t i);
+DBusHandlerResult avahi_dbus_respond_variant_uint32(DBusConnection *c, DBusMessage *m, uint32_t u);
+DBusHandlerResult avahi_dbus_respond_variant_boolean(DBusConnection *c, DBusMessage *m, int b);
 
 void avahi_dbus_append_server_error(DBusMessage *reply);
 

--- a/avahi-daemon/org.freedesktop.Avahi.Server.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.Server.xml
@@ -29,8 +29,24 @@
     </method>
   </interface>
 
-  <interface name="org.freedesktop.Avahi.Server">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="values" type="a{sv}" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+  </interface>
 
+  <interface name="org.freedesktop.Avahi.Server">
     <method name="GetVersionString">
       <arg name="version" type="s" direction="out"/>
     </method>
@@ -217,6 +233,21 @@
   </interface>
 
   <interface name="org.freedesktop.Avahi.Server2">
+    <property name="VersionString" type="s" access="read"/>
+
+    <property name="APIVersion" type="u" access="read"/>
+
+    <property name="HostName" type="s" access="readwrite"/>
+
+    <property name="HostNameFqdn" type="s" access="read"/>
+
+    <property name="DomainName" type="s" access="read"/>
+
+    <property name="NSSSupportAvailable" type="b" access="read"/>
+
+    <property name="State" type="i" access="read"/>
+
+    <property name="LocalServiceCookie" type="u" access="read"/>
 
     <method name="GetVersionString">
       <arg name="version" type="s" direction="out"/>


### PR DESCRIPTION
I noticed the D-Bus API didn't make use of D-Bus properties. It turned out to be a bit harder than I expected with libdbus. Properties would make it easier for a client to know if these values changed (e.g. State, HostName) through standard D-Bus methods. Unfortunately I guess the old methods would need to remain unless you made an org.freedesktop.Avahi.Server3 API.