### PR TITLE
Fix Readme's URL 

### DIFF
--- a/README
+++ b/README
@@ -23,8 +23,8 @@ CIA:
 FRESHMEAT:
 	http://freshmeat.net/projects/avahi/
 
-OHLOH:
-	http://www.ohloh.net/projects/avahi/
+Open Hub:
+    https://www.openhub.net/projects/avahi/
 
 AUTHORS:
 	Lennart Poettering


### PR DESCRIPTION
## What
remove ohlow's url and add openhub's url to README

## WHY
ohlow was deleted.
https://www.openhub.net/p/ohloh