### PR TITLE
Fix NULL pointer crashes from #175

### DIFF
--- a/avahi-core/browse-dns-server.c
+++ b/avahi-core/browse-dns-server.c
@@ -343,6 +343,9 @@ AvahiSDNSServerBrowser *avahi_s_dns_server_browser_new(
         AvahiSDNSServerBrowser* b;
 
         b = avahi_s_dns_server_browser_prepare(server, interface, protocol, domain, type, aprotocol, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_dns_server_browser_start(b);
 
         return b;

--- a/avahi-core/browse-domain.c
+++ b/avahi-core/browse-domain.c
@@ -253,6 +253,9 @@ AvahiSDomainBrowser *avahi_s_domain_browser_new(
         AvahiSDomainBrowser *b;
 
         b = avahi_s_domain_browser_prepare(server, interface, protocol, domain, type, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_domain_browser_start(b);
 
         return b;

--- a/avahi-core/browse-service-type.c
+++ b/avahi-core/browse-service-type.c
@@ -171,6 +171,9 @@ AvahiSServiceTypeBrowser *avahi_s_service_type_browser_new(
         AvahiSServiceTypeBrowser *b;
 
         b = avahi_s_service_type_browser_prepare(server, interface, protocol, domain, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_service_type_browser_start(b);
 
         return b;

--- a/avahi-core/browse-service.c
+++ b/avahi-core/browse-service.c
@@ -184,6 +184,9 @@ AvahiSServiceBrowser *avahi_s_service_browser_new(
         AvahiSServiceBrowser *b;
 
         b = avahi_s_service_browser_prepare(server, interface, protocol, service_type, domain, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_service_browser_start(b);
 
         return b;

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -634,6 +634,9 @@ AvahiSRecordBrowser *avahi_s_record_browser_new(
         AvahiSRecordBrowser *b;
 
         b = avahi_s_record_browser_prepare(server, interface, protocol, key, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_record_browser_start_query(b);
 
         return b;

--- a/avahi-core/resolve-address.c
+++ b/avahi-core/resolve-address.c
@@ -286,6 +286,9 @@ AvahiSAddressResolver *avahi_s_address_resolver_new(
         AvahiSAddressResolver *b;
 
         b = avahi_s_address_resolver_prepare(server, interface, protocol, address, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_address_resolver_start(b);
 
         return b;

--- a/avahi-core/resolve-host-name.c
+++ b/avahi-core/resolve-host-name.c
@@ -318,6 +318,9 @@ AvahiSHostNameResolver *avahi_s_host_name_resolver_new(
         AvahiSHostNameResolver *b;
 
         b = avahi_s_host_name_resolver_prepare(server, interface, protocol, host_name, aprotocol, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_host_name_resolver_start(b);
 
         return b;

--- a/avahi-core/resolve-service.c
+++ b/avahi-core/resolve-service.c
@@ -519,6 +519,9 @@ AvahiSServiceResolver *avahi_s_service_resolver_new(
         AvahiSServiceResolver *b;
 
         b = avahi_s_service_resolver_prepare(server, interface, protocol, name, type, domain, aprotocol, flags, callback, userdata);
+        if (!b)
+            return NULL;
+
         avahi_s_service_resolver_start(b);
 
         return b;


### PR DESCRIPTION
avahi-daemon is crashing when running `ping .local`.
The crash is due to failing assertion from NULL pointer.
Add missing NULL pointer checks to fix it.

Regression introduced in #175
@simoninator @lathiat 