### PR TITLE
skip error handling.

### DIFF
--- a/avahi-daemon/chroot.c
+++ b/avahi-daemon/chroot.c
@@ -188,8 +188,8 @@ static int recv_fd(int fd) {
             return -1;
         }
 
-        assert(h->cmsg_len = CMSG_LEN(sizeof(int)));
-        assert(h->cmsg_level = SOL_SOCKET);
+        assert(h->cmsg_len == CMSG_LEN(sizeof(int)));
+        assert(h->cmsg_level == SOL_SOCKET);
         assert(h->cmsg_type == SCM_RIGHTS);
 
         return *((int*)CMSG_DATA(h));


### PR DESCRIPTION
using an assignment instead of a comparison means that these parts of the code cannot signal possible errors.

which results in no error handling.