### PR TITLE
dbus: Use non-deprecated installation path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -674,7 +674,7 @@ if test "x$HAVE_DBUS" = "xyes" ; then
     if ! test -z "$with_dbus_sys" ; then
         DBUS_SYS_DIR="$with_dbus_sys"
     else
-        DBUS_SYS_DIR="${sysconfdir}/dbus-1/system.d"
+        DBUS_SYS_DIR="${datadir}/dbus-1/system.d"
     fi
     AC_SUBST(DBUS_SYS_DIR)
 


### PR DESCRIPTION
Quoting from [D-Bus 1.14.0 release notes](https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-1.14.0/NEWS#L45-51):

> Third-party software should install default dbus policies for the system  bus into `${datadir}/dbus-1/system.d` (this has been supported since dbus 1.10, released in August 2015). Installing default dbus policies in `${sysconfdir}/dbus-1/system.d` is now considered to be deprecated.