### PR TITLE
build: Use runstatedir instead home-brewn variable

### DIFF
--- a/avahi-autoipd/Makefile.am
+++ b/avahi-autoipd/Makefile.am
@@ -25,7 +25,7 @@ AM_CFLAGS= \
 
 # This cool debug trap works on i386/gcc only
 AM_CFLAGS+='-DDEBUG_TRAP=__asm__("int $$3")' \
-	-DAVAHI_RUNTIME_DIR=\"$(avahi_runtime_dir)/\" \
+	-DAVAHI_RUNTIME_DIR=\"$(runstatedir)/\" \
 	-DAVAHI_IPCONF_SCRIPT=\"$(pkgsysconfdir)/avahi-autoipd.action\" \
 	-DAVAHI_IPDATA_DIR=\"$(localstatedir)/lib/avahi-autoipd\"
 

--- a/avahi-daemon/Makefile.am
+++ b/avahi-daemon/Makefile.am
@@ -29,7 +29,7 @@ introspectiondir=$(datadir)/dbus-1/interfaces
 dbussystemservicesdir=$(datadir)/dbus-1/system-services
 
 AM_CFLAGS+= \
-	-DAVAHI_DAEMON_RUNTIME_DIR=\"$(avahi_runtime_dir)/avahi-daemon/\" \
+	-DAVAHI_DAEMON_RUNTIME_DIR=\"$(runstatedir)/avahi-daemon/\" \
 	-DAVAHI_SOCKET=\"$(avahi_socket)\" \
 	-DAVAHI_SERVICE_DIR=\"$(servicedir)\" \
 	-DAVAHI_CONFIG_FILE=\"$(pkgsysconfdir)/avahi-daemon.conf\" \
@@ -80,7 +80,7 @@ dist_pkgdata_DATA = \
 
 %.socket: %.socket.in
 	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' \
-		-e 's,@avahi_runtime_dir\@,$(avahi_runtime_dir),g' $< > $@
+		-e 's,@runstatedir\@,$(runstatedir),g' $< > $@
 
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
@@ -168,4 +168,4 @@ xmllint:
 	done
 
 install-data-local:
-	test -z "$(avahi_runtime_dir)" || $(MKDIR_P) "$(DESTDIR)$(avahi_runtime_dir)"
+	test -z "$(runstatedir)" || $(MKDIR_P) "$(DESTDIR)$(runstatedir)"

--- a/avahi-daemon/avahi-daemon.socket.in
+++ b/avahi-daemon/avahi-daemon.socket.in
@@ -19,7 +19,7 @@
 Description=Avahi mDNS/DNS-SD Stack Activation Socket
 
 [Socket]
-ListenStream=@avahi_runtime_dir@/avahi-daemon/socket
+ListenStream=@runstatedir@/avahi-daemon/socket
 
 [Install]
 WantedBy=sockets.target

--- a/avahi-dnsconfd/Makefile.am
+++ b/avahi-dnsconfd/Makefile.am
@@ -24,7 +24,7 @@ pkgsysconfdir=$(sysconfdir)/avahi
 
 AM_CFLAGS= \
 	-I$(top_srcdir) \
-	-DAVAHI_RUNTIME_DIR=\"$(avahi_runtime_dir)/\" \
+	-DAVAHI_RUNTIME_DIR=\"$(runstatedir)/\" \
 	-DAVAHI_SOCKET=\"$(avahi_socket)\" \
 	-DAVAHI_DNSCONF_SCRIPT=\"$(pkgsysconfdir)/avahi-dnsconfd.action\"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1020,12 +1020,14 @@ fi
 AC_SUBST(AVAHI_AUTOIPD_GROUP)
 AC_DEFINE_UNQUOTED(AVAHI_AUTOIPD_GROUP,"$AVAHI_AUTOIPD_GROUP", [Group for running the avahi-autoipd daemon])
 
+# Autoconf 2.70 supports this natively but it is not yet universally available.
+AS_IF([test -z "${runstatedir}"], [runstatedir='${localstatedir}/run'])
+AC_SUBST([runstatedir])
+
 #
 # Avahi runtime dir
 #
-avahi_runtime_dir="/run"
-avahi_socket="${avahi_runtime_dir}/avahi-daemon/socket"
-AC_SUBST(avahi_runtime_dir)
+avahi_socket="${runstatedir}/avahi-daemon/socket"
 AC_SUBST(avahi_socket)
 
 #


### PR DESCRIPTION
Switching to a standard variable will allow to simplify downstream packages. The variable was introduced in Autoconf 2.70: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

Fixes: https://github.com/lathiat/avahi/issues/137