### PR TITLE
Typo fixes

### DIFF
--- a/avahi-common/rlist.h
+++ b/avahi-common/rlist.h
@@ -38,7 +38,7 @@ struct AvahiRList {
 /** Prepend a new item to the beginning of the list and return the new beginning */
 AvahiRList* avahi_rlist_prepend(AvahiRList *r, void *data);
 
-/** Remove the first occurence of the specified item from the list and return the new beginning */
+/** Remove the first occurrence of the specified item from the list and return the new beginning */
 AvahiRList* avahi_rlist_remove(AvahiRList *r, void *data);
 
 /** Remove the specified item from the list and return the new beginning */

--- a/avahi-gobject/ga-entry-group.c
+++ b/avahi-gobject/ga-entry-group.c
@@ -189,7 +189,7 @@ static GQuark detail_for_state(AvahiEntryGroupState state) {
         const gchar *name;
         GQuark quark;
     } states[] = {
-        { AVAHI_ENTRY_GROUP_UNCOMMITED, "uncommited", 0},
+        { AVAHI_ENTRY_GROUP_UNCOMMITED, "uncommitted", 0},
         { AVAHI_ENTRY_GROUP_REGISTERING, "registering", 0},
         { AVAHI_ENTRY_GROUP_ESTABLISHED, "established", 0},
         { AVAHI_ENTRY_GROUP_COLLISION, "collistion", 0},

--- a/man/avahi.service.5.xml.in
+++ b/man/avahi.service.5.xml.in
@@ -45,7 +45,7 @@
       <option>
         <p><opt>&lt;name replace-wildcards="yes|no"&gt;</opt> The
         service name. If <opt>replace-wildcards</opt> is "yes", any
-        occurence of the string "%h" will be replaced by the local
+        occurrence of the string "%h" will be replaced by the local
         host name. This can be used for service names like "Remote
         Terminal on %h". If <opt>replace-wildcards</opt> is not
         specified, defaults to "no".</p>


### PR DESCRIPTION
spotted by lintian:
```
I: libavahi-gobject0: spelling-error-in-binary usr/lib/x86_64-linux-gnu/libavahi-gobject.so.0.0.5 uncommited uncommitted
I: avahi-daemon: typo-in-manual-page usr/share/man/man5/avahi.service.5.gz line 13 occurence occurrence
```