### PR TITLE
Fix remove of probing announcer

### DIFF
--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -38,6 +38,12 @@ static void remove_announcer(AvahiServer *s, AvahiAnnouncer *a) {
     assert(s);
     assert(a);
 
+    if (a->state == AVAHI_PROBING && a->entry->group) {
+        assert(a->entry->group->n_probing);
+        a->entry->group->n_probing--;
+        avahi_s_entry_group_check_probed(a->entry->group, 1);
+    }
+
     if (a->time_event)
         avahi_time_event_free(a->time_event);
 


### PR DESCRIPTION
If an announcer is in state AVAHI_PROBING when it is removed (because
the interface is no longer relevant, for example) then it must decrement
the n_probing count in the associated group (if any).

Otherwise, any remaining announcers in the group will only advance
to state AVAHI_WAITING and never be triggered to advance to state
AVAHI_ANNOUNCING.

Resolves: #383
Signed-off-by: Alan Young <consult.awy@gmail.com>