### PR TITLE
Fix escape representation of non-printable characters

### DIFF
--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -159,9 +159,9 @@ char *avahi_escape_label(const char* src, size_t src_length, char **ret_name, si
                 return NULL;
 
             *((*ret_name) ++) = '\\';
-            *((*ret_name) ++) = '0' + (char)  ((uint8_t) *src / 100);
-            *((*ret_name) ++) = '0' + (char) (((uint8_t) *src / 10) % 10);
-            *((*ret_name) ++) = '0' + (char)  ((uint8_t) *src % 10);
+            *((*ret_name) ++) = '0' + (char)  ((uint8_t) *src / 64);
+            *((*ret_name) ++) = '0' + (char) (((uint8_t) *src / 8) % 8);
+            *((*ret_name) ++) = '0' + (char)  ((uint8_t) *src % 8);
 
             (*ret_size) -= 4;
         }


### PR DESCRIPTION
The avahi_escape_label function generates a string which uses an escape
sequence to represent non-printable characters.  The representation used
does not conform to shell/C/… rules, though.  It uses a zero-padded
decimal representation.  A space = U+0020 character is therefore printed
as \032.  In shell/C/… strings this represents U+001a.  At least for me
this is highly confusing and I questioned my settings.

Therefore I suggest to use the traditional octal representation.