### PR TITLE
Hide desktop icons by default

### DIFF
--- a/avahi-python/avahi-discover/avahi-discover.desktop.in.in
+++ b/avahi-python/avahi-discover/avahi-discover.desktop.in.in
@@ -8,3 +8,4 @@ Type=Application
 Icon=network-wired
 Categories=GNOME;System;
 StartupNotify=false
+NoDisplay=true

--- a/avahi-ui/bssh.desktop.in.in
+++ b/avahi-ui/bssh.desktop.in.in
@@ -8,3 +8,4 @@ Type=Application
 Icon=network-wired
 Categories=GNOME;Network;
 StartupNotify=false
+NoDisplay=true

--- a/avahi-ui/bvnc.desktop.in.in
+++ b/avahi-ui/bvnc.desktop.in.in
@@ -8,3 +8,4 @@ Type=Application
 Icon=network-wired
 Categories=GNOME;Network;
 StartupNotify=false
+NoDisplay=true


### PR DESCRIPTION
By default, the following files will appear in an applications menu for any common desktop environment, for example gnome. I suggest it would be a better default to hide these icons, so that the average user doesn't see an icon they don't understand or need to use.

- avahi-discover.desktop
- bvnc.desktop
- bssh.desktop