### PR TITLE
CI: turn on CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,57 @@
+---
+# See: https://google.github.io/oss-fuzz/getting-started/continuous-integration/
+
+name: CIFuzz
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  Fuzzing:
+    permissions:
+      actions: read
+      contents: read
+
+    runs-on: ubuntu-22.04
+    if: github.repository == 'lathiat/avahi'
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ matrix.architecture }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+        architecture: [x86_64]
+        include:
+          - sanitizer: address
+            architecture: i386
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'avahi'
+          dry-run: false
+          allowed-broken-targets-percentage: 0
+          sanitizer: ${{ matrix.sanitizer }}
+          architecture: ${{ matrix.architecture }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'avahi'
+          fuzz-seconds: 180
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Upload Crash
+        uses: actions/upload-artifact@v3
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: ${{ matrix.sanitizer }}-${{ matrix.architecture }}-artifacts
+          path: ./out/artifacts


### PR DESCRIPTION
It should help to somewhat excercise the code paths consuming DNS packets under ASan, UBSan and MSan when PRs are opened: https://google.github.io/oss-fuzz/getting-started/continuous-integration/. Other than that it should also help to make sure that new PRs don't break OSS-Fuzz builds.

FWIW I'm planning to move the fuzzing infrastructure to the avahi repository to make it easier to extend the coverage but until then it still should be possible to run the fuzz targets on PRs.