### PR TITLE
avahi-core: rearrange deallocations in avahi_time_event_queue_new a bit

### DIFF
--- a/avahi-core/timeeventq.c
+++ b/avahi-core/timeeventq.c
@@ -135,10 +135,10 @@ AvahiTimeEventQueue* avahi_time_event_queue_new(const AvahiPoll *poll_api) {
 oom:
 
     if (q) {
-        avahi_free(q);
-
         if (q->prioq)
             avahi_prio_queue_free(q->prioq);
+
+        avahi_free(q);
     }
 
     return NULL;


### PR DESCRIPTION
Reported by Coverity Scan.

I was testing a script sending avahi to Coverity Scan and it was the first warning it threw at me. I think combined with https://github.com/lathiat/avahi/pull/202 it should make Coverity a bit more happy.