### PR TITLE
tests: run more unit tests automatically

### DIFF
--- a/avahi-common/Makefile.am
+++ b/avahi-common/Makefile.am
@@ -48,6 +48,15 @@ noinst_PROGRAMS = \
 	watch-test \
 	watch-test-thread \
 	utf8-test
+
+TESTS = \
+	strlst-test \
+	domain-test \
+	alternative-test \
+	timeval-test \
+	watch-test \
+	watch-test-thread \
+	utf8-test
 endif
 
 lib_LTLIBRARIES = \

--- a/avahi-glib/Makefile.am
+++ b/avahi-glib/Makefile.am
@@ -34,6 +34,9 @@ lib_LTLIBRARIES = \
 if ENABLE_TESTS
 noinst_PROGRAMS = \
 	glib-watch-test
+
+TESTS = \
+	glib-watch-test
 endif
 
 libavahi_glib_la_SOURCES = \

--- a/avahi-libevent/Makefile.am
+++ b/avahi-libevent/Makefile.am
@@ -33,6 +33,9 @@ lib_LTLIBRARIES = \
 if ENABLE_TESTS
 noinst_PROGRAMS = \
 	libevent-watch-test
+
+TESTS = \
+	libevent-watch-test
 endif
 
 libavahi_libevent_la_SOURCES = \


### PR DESCRIPTION
To get `make check` to run tests automatically they should be added to the TESTS variable: https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html

Unlike functional tests like, say, avahi-test or client-test that should be run in suitable environments those tests are actually unit tests and can safely be run everywhere.

It should make the coverage go from 3% (https://coveralls.io/builds/54821508) to almost 10% (https://coveralls.io/builds/54825736). Admiteddly it isn't much but at least it should cover PRs/patches touching avahi-common and since the testing infrastructure is somewhat ready it should be possible to start adding/extending basic tests or use it to catch obvious regressions automatically.

The PR was tested on aarch64, i386, ppc64le, s390x and x86_64.