### PR TITLE
CI: build avahi on aarch64, i386, ppc64le, s390x, x86_64 on PRs

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,39 @@
+---
+specfile_path: .packit_rpm/avahi.spec
+synced_files:
+  - .packit.yaml
+  - src: .packit_rpm/avahi.spec
+    dest: avahi.spec
+upstream_package_name: avahi
+downstream_package_name: avahi
+upstream_tag_template: "v{version}"
+srpm_build_deps: []
+
+actions:
+  post-upstream-clone:
+    # Use the Fedora Rawhide specfile
+    - "git clone https://src.fedoraproject.org/rpms/avahi .packit_rpm --depth=1"
+    # Drop the "sources" file so rebase-helper doesn't think it's a dist-git
+    - "rm -fv .packit_rpm/sources"
+    # Drop all patches apart from avahi-0.6.30-mono-libdir.patch
+    - "sed -ri '/^Patch[0-9]+\\:.+\\.patch/d' .packit_rpm/avahi.spec"
+    - "sed -ri '/^## downstream patches/aPatch100: avahi-0.6.30-mono-libdir.patch' .packit_rpm/avahi.spec"
+    # Get around RPM build errors:
+    # line 366: It's not recommended to have unversioned Obsoletes: Obsoletes:        howl-libs
+    # line 376: It's not recommended to have unversioned Obsoletes: Obsoletes:        howl-devel
+    - "sed -i '/^Obsoletes: *howl/d' .packit_rpm/avahi.spec"
+    # Build unit tests
+    - "sed -i '/^%configure /a--enable-tests \\\\' .packit_rpm/avahi.spec"
+    # Run make check
+    - "sed -i '/^%check$/amake check VERBOSE=1' .packit_rpm/avahi.spec"
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-37-aarch64
+    - fedora-37-i386
+    - fedora-37-ppc64le
+    - fedora-37-s390x
+    - fedora-37-x86_64


### PR DESCRIPTION
It's a draft because the repository should be hooked up to Packit first: https://packit.dev/docs/guide/#github.

It already works in the sense that it can build PRs and run the unit tests on those architectures: https://copr.fedorainfracloud.org/coprs/packit/evverx-avahi-3/build/5083135/. I think once it's on it should be possible to start rebasing the PRs that have already been tested in the wild on top of the master branch and if Packit is green there it should help to be more or less sure that they can also be built downstream on 32-bit, 64-bit, BE and LE architectures.

I'll remove a couple kludges once https://src.fedoraproject.org/rpms/avahi/pull-request/10 gets merged.