### PR TITLE
CI: run the unit tests under ASan/UBSan coming with clang

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -20,7 +20,11 @@ case "$1" in
             export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
         fi
 
-        ./bootstrap.sh --enable-tests --prefix=/usr
+        if ! ./bootstrap.sh --enable-tests --prefix=/usr; then
+            cat config.log
+            exit 1
+        fi
+
         make -j"$(nproc)" V=1
         make check VERBOSE=1
         ;;

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -16,6 +16,7 @@ case "$1" in
     build)
         if [[ "$ASAN_UBSAN" == true ]]; then
             export CFLAGS="-fsanitize=address,undefined -g"
+            export CXXFLAGS="$CFLAGS"
             export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
             export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -18,6 +18,15 @@ case "$1" in
             export CFLAGS="-fsanitize=address,undefined -g"
             export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
             export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
+
+            # This kludge prevents autoconf from complaining about pthreads. The right fix would be
+            # to replace that out-of-date acx_pthread.m4 with ax_pthread.m4 but it isn't clear how
+            # safe it is to bump autoconf: https://github.com/lathiat/avahi/pull/377. Since it's a
+            # niche use case and nobody else seems to have complained about it so far let's keep the
+            # kludge until some sort of policy covering build dependencies is settled.
+            if [[ "$CC" == clang ]]; then
+                sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
+            fi
         fi
 
         if ! ./bootstrap.sh --enable-tests --prefix=/usr; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - { CC: "gcc" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
           - { CC: "clang" }
+          - { CC: "clang", ASAN_UBSAN: "true" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { CC: "gcc" }
-          - { CC: "gcc", ASAN_UBSAN: "true" }
-          - { CC: "clang" }
-          - { CC: "clang", ASAN_UBSAN: "true" }
+          - { CC: "gcc", CXX: "g++" }
+          - { CC: "gcc", CXX: "g++", ASAN_UBSAN: "true" }
+          - { CC: "clang", CXX: "clang++" }
+          - { CC: "clang", CXX: "clang++", ASAN_UBSAN: "true" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout


### PR DESCRIPTION
~~I think avahi fails to build with clang and ASan/UBsan at the moment so it should be a draft until it works.~~

avahi still fails to build with clang and ASan/UBsan but I got it around with a kludge touching the CI only for now.