### PR TITLE
CI: turn on as many fatal warnings as possible

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,6 +4,23 @@ set -eux
 set -o pipefail
 
 export ASAN_UBSAN=${ASAN_UBSAN:-false}
+export CFLAGS=${CFLAGS:-}
+export WERROR=${WERROR:-false}
+
+autogen_args=" --enable-compat-howl --enable-compat-libdns_sd --enable-tests"
+
+# CFLAGS can be used to turn off warnings globally but it doesn't make sense to
+# ignore, say, format-truncation everywhere when only one component triggers it.
+# This function patches Makefiles to disable warnings where it's actually necessary
+# to let the CI keep catching them in other places. It's a kludge and it should
+# be removed once all warnings avahi triggers are fixed.
+ignore_warnings() {
+    local _component="$1"
+    shift
+    for warning in "$@"; do
+        sed -i 's/^\(AM_CFLAGS=\)\(.*\)/\1-Wno-error='"$warning"' \2/' "$_component/Makefile.am"
+    done
+}
 
 case "$1" in
     install-build-deps)
@@ -12,15 +29,63 @@ case "$1" in
         apt-get build-dep -y avahi
         apt-get install -y libevent-dev qtbase5-dev
         apt-get install -y gcc clang
+        apt-get install -y autoconf-archive
         ;;
     build)
         if [[ "$ASAN_UBSAN" == true ]]; then
-            export CFLAGS="-fsanitize=address,undefined -g"
+            CFLAGS+=" -fsanitize=address,undefined -g"
             export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
             export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
         fi
 
-        ./bootstrap.sh --enable-tests --prefix=/usr
+        if [[ "$WERROR" == true ]]; then
+            # acx_pthread isn't compatible with CFLAGS=-Werror at all so it's just replaced
+            # with ax_pthread from autoconf-archive.
+            rm -rf common/acx_pthread.m4
+
+            CFLAGS+=" -Werror"
+
+            # The following warnings are ignored because it's hard to fix them all in one fell swoop.
+            # Ideally they should be fixed one by one and removed from here to let compilers catch them
+            # automatically on PRs.
+            if [[ "$CC" == gcc ]]; then
+                ignore_warnings avahi-autoipd unused-result
+                ignore_warnings avahi-common unused-result
+                ignore_warnings avahi-compat-howl cast-function-type missing-prototypes pedantic pointer-sign
+                ignore_warnings avahi-compat-howl/samples discarded-qualifiers pointer-sign shadow unused-parameter unused-variable
+                ignore_warnings avahi-compat-libdns_sd pedantic
+                ignore_warnings avahi-core format-truncation
+                ignore_warnings avahi-daemon stringop-truncation unused-result
+                ignore_warnings avahi-dnsconfd unused-result
+                ignore_warnings avahi-glib deprecated-declarations
+                ignore_warnings avahi-ui deprecated-declarations implicit-fallthrough maybe-uninitialized
+                ignore_warnings avahi-utils unused-result
+
+                # avahi-gobject triggers a lot of warnings like
+                # "Deprecated pre-processor symbol: replace with "G_ADD_PRIVATE""
+                # and judging by https://gitlab.gnome.org/GNOME/glib/-/issues/2247
+                # they can't be disabled when code is built with gcc with -Werror.
+                autogen_args+=" --disable-gobject"
+            elif [[ "$CC" == clang ]]; then
+                CFLAGS+=" -Wno-error=strict-prototypes"
+
+                ignore_warnings avahi-autoipd cast-align
+                ignore_warnings avahi-client varargs
+                ignore_warnings avahi-compat-howl cast-align missing-prototypes
+                ignore_warnings avahi-compat-howl/samples cast-align incompatible-pointer-types-discards-qualifiers pointer-sign shadow unused-parameter unused-variable
+                ignore_warnings avahi-core cast-align logical-not-parentheses varargs
+                ignore_warnings avahi-daemon cast-align
+                ignore_warnings avahi-glib deprecated-declarations enum-conversion
+                ignore_warnings avahi-gobject deprecated enum-conversion
+                ignore_warnings avahi-ui deprecated-declarations
+            fi
+        fi
+
+        if ! ./autogen.sh $autogen_args --prefix=/usr; then
+            cat config.log
+            exit 1
+        fi
+
         make -j"$(nproc)" V=1
         make check VERBOSE=1
         ;;

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,6 +4,7 @@ set -eux
 set -o pipefail
 
 export ASAN_UBSAN=${ASAN_UBSAN:-false}
+export BUILD_ONLY=${BUILD_ONLY:-false}
 export CFLAGS=${CFLAGS:-}
 export WERROR=${WERROR:-false}
 
@@ -98,6 +99,11 @@ case "$1" in
         fi
 
         make -j"$(nproc)" V=1
+
+        if [[ "$BUILD_ONLY" == true ]]; then
+            exit 0
+        fi
+
         make check VERBOSE=1
         ;;
     *)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,10 @@ jobs:
       matrix:
         env:
           - { CC: "gcc" }
+          - { CC: "gcc", WERROR: "true" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
           - { CC: "clang" }
+          - { CC: "clang", WERROR: "true" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           - { CC: "clang", WERROR: "true", CFLAGS: "-O1" }
           - { CC: "clang", WERROR: "true", CFLAGS: "-O2" }
           - { CC: "clang", WERROR: "true", CFLAGS: "-O3" }
+          - { CC: "clang", ASAN_UBSAN: "true" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,16 @@ jobs:
       matrix:
         env:
           - { CC: "gcc" }
-          - { CC: "gcc", WERROR: "true" }
+          - { CC: "gcc", WERROR: "true", CFLAGS: "-O0" }
+          - { CC: "gcc", WERROR: "true", CFLAGS: "-O1" }
+          - { CC: "gcc", WERROR: "true", CFLAGS: "-O2" }
+          - { CC: "gcc", WERROR: "true", CFLAGS: "-O3" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
           - { CC: "clang" }
-          - { CC: "clang", WERROR: "true" }
+          - { CC: "clang", WERROR: "true", CFLAGS: "-O0" }
+          - { CC: "clang", WERROR: "true", CFLAGS: "-O1" }
+          - { CC: "clang", WERROR: "true", CFLAGS: "-O2" }
+          - { CC: "clang", WERROR: "true", CFLAGS: "-O3" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  CC: "gcc"
+  BUILD_ONLY: "true"
+
 jobs:
   analyze:
     name: Analyze
@@ -26,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['cpp', 'python']
+        language: ['cpp', 'python', 'csharp']
 
     steps:
     - name: Checkout repository
@@ -39,8 +43,7 @@ jobs:
 
     - run: sudo -E .github/workflows/build.sh install-build-deps
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - run: .github/workflows/build.sh build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -66,7 +66,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     printf("name: <>; type: <%s>; domain <%s>\n", type, domain);
 
 
-    p = "--:---\\\\\\123\\065_äöü\\064\\.\\\\sjöödfhh.sdfjhskjdf";
+    p = "--:---\\\\\\123\\065_\344\366\374\\064\\.\\\\sj\366\366dfhh.sdfjhskjdf";
     printf("unescaped: <%s>, rest: %s\n", avahi_unescape_label(&p, t, sizeof(t)), p);
 
     size = sizeof(r);

--- a/avahi-common/utf8-test.c
+++ b/avahi-common/utf8-test.c
@@ -30,7 +30,7 @@
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     assert(avahi_utf8_valid("hallo"));
-    assert(!avahi_utf8_valid("üxknürz"));
+    assert(!avahi_utf8_valid("\374xkn\374rz"));
     assert(avahi_utf8_valid("Ã¼xknÃ¼rz"));
 
     return 0;


### PR DESCRIPTION
The idea is to turn on -Werror eventually to let compilers do their thing and catch various mistakes automatically. At this point it isn't possible to fully turn it on though so a bunch of warnings are just ignored. They should be fixed but until then the CI should at least be able to prevent new slip-ups from making it into the repository.