### PR TITLE
dbus: deny SetHostName via org.freedesktop.Avahi.Server2 as well

### DIFF
--- a/avahi-daemon/avahi-dbus.conf.in
+++ b/avahi-daemon/avahi-dbus.conf.in
@@ -18,6 +18,8 @@
 
     <deny send_destination="org.freedesktop.Avahi"
           send_interface="org.freedesktop.Avahi.Server" send_member="SetHostName"/>
+    <deny send_destination="org.freedesktop.Avahi"
+          send_interface="org.freedesktop.Avahi.Server2" send_member="SetHostName"/>
   </policy>
 
   <!-- Allow everything, including access to SetHostName to users of the group "@AVAHI_PRIV_ACCESS_GROUP@" -->


### PR DESCRIPTION
Looks like the policy wasn't updated when the Server2 interface was introduced.

It's a follow-up to https://github.com/lathiat/avahi/pull/175

@lathiat @pemensik could you take a look?