### PR TITLE
Include wide-area lookups in cache dump

### DIFF
--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -346,6 +346,8 @@ const AvahiRecord *avahi_server_iterate(AvahiServer *s, AvahiSEntryGroup *g, voi
 
 int avahi_server_dump(AvahiServer *s, AvahiDumpCallback callback, void* userdata) {
     AvahiEntry *e;
+    char ln[256];
+    size_t deads = 0;
 
     assert(s);
     assert(callback);
@@ -354,10 +356,11 @@ int avahi_server_dump(AvahiServer *s, AvahiDumpCallback callback, void* userdata
 
     for (e = s->entries; e; e = e->entries_next) {
         char *t;
-        char ln[256];
 
-        if (e->dead)
+        if (e->dead) {
+            ++deads;
             continue;
+	}
 
         if (!(t = avahi_record_to_string(e->record)))
             return avahi_server_set_errno(s, AVAHI_ERR_NO_MEMORY);
@@ -367,6 +370,9 @@ int avahi_server_dump(AvahiServer *s, AvahiDumpCallback callback, void* userdata
 
         callback(ln, userdata);
     }
+
+    snprintf(ln, sizeof(ln), ";; dead entries: %zu", deads);
+    callback(ln, userdata);
 
     avahi_dump_caches(s->monitor, callback, userdata);
 

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -671,8 +671,23 @@ void avahi_wide_area_set_servers(AvahiWideAreaLookupEngine *e, const AvahiAddres
     avahi_wide_area_clear_cache(e);
 }
 
+static void avahi_wide_area_dump_lookup(AvahiWideAreaLookup *l, AvahiDumpCallback callback, void* userdata) {
+    char *k, *t;
+
+    k = avahi_key_to_string(l->key);
+    if (!k)
+        return;
+    t = avahi_strdup_printf("%s ; n_send=%i%s", k, l->n_send, l->dead ? " (dead)" : "");
+    avahi_free(k);
+    if (!t)
+        return;
+    callback(t, userdata);
+    avahi_free(t);
+}
+
 void avahi_wide_area_cache_dump(AvahiWideAreaLookupEngine *e, AvahiDumpCallback callback, void* userdata) {
     AvahiWideAreaCacheEntry *c;
+    AvahiWideAreaLookup *l;
 
     assert(e);
     assert(callback);
@@ -683,6 +698,11 @@ void avahi_wide_area_cache_dump(AvahiWideAreaLookupEngine *e, AvahiDumpCallback 
         char *t = avahi_record_to_string(c->record);
         callback(t, userdata);
         avahi_free(t);
+    }
+
+    callback(";; WIDE AREA LOOKUPS ;;; ", userdata);
+    for (l = e->lookups; l; l = l->lookups_next) {
+        avahi_wide_area_dump_lookup(l, callback, userdata);
     }
 }
 


### PR DESCRIPTION
Include counts of dead entries in mdns resolution. Include lookups active and dead for wide-area. Attempt to debug easier PR#411 issue.