### PR TITLE
ci: import the OSS-Fuzz build script and fuzz targets

### DIFF
--- a/fuzz/fuzz-consume-key.c
+++ b/fuzz/fuzz-consume-key.c
@@ -1,0 +1,44 @@
+/***
+  This file is part of avahi.
+
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+  Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "avahi-common/malloc.h"
+#include "avahi-core/dns.h"
+#include "avahi-core/log.h"
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    avahi_set_log_function(log_function);
+    AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+    memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
+    packet->size = size;
+    AvahiKey* key = avahi_dns_packet_consume_key(packet, NULL);
+    if (key) {
+        avahi_key_is_valid(key);
+        char *s = avahi_key_to_string(key);
+        avahi_free(s);
+        avahi_key_unref(key);
+    }
+    avahi_dns_packet_free(packet);
+
+    return 0;
+}

--- a/fuzz/fuzz-consume-record.c
+++ b/fuzz/fuzz-consume-record.c
@@ -1,0 +1,44 @@
+/***
+  This file is part of avahi.
+
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+  Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "avahi-common/malloc.h"
+#include "avahi-core/dns.h"
+#include "avahi-core/log.h"
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    avahi_set_log_function(log_function);
+    AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+    memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
+    packet->size = size;
+    AvahiRecord* rec = avahi_dns_packet_consume_record(packet, NULL);
+    if (rec) {
+        avahi_record_is_valid(rec);
+        char *s = avahi_record_to_string(rec);
+        avahi_free(s);
+        avahi_record_unref(rec);
+    }
+    avahi_dns_packet_free(packet);
+
+    return 0;
+}

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+set -eux
+
+sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
+
+./autogen.sh \
+    --disable-stack-protector --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk \
+    --disable-gtk3 --disable-dbus --disable-gdbm --disable-libdaemon --disable-python \
+    --disable-manpages --disable-mono --disable-monodoc --disable-glib --disable-gobject \
+    --disable-libevent
+
+make -j"$(nproc)" V=1
+
+for f in fuzz/fuzz-*.c; do
+    fuzz_target=$(basename "$f" .c)
+    $CC -c $CFLAGS -I. \
+        "fuzz/$fuzz_target.c" \
+        -o "$fuzz_target.o"
+
+    $CXX $CXXFLAGS \
+        "$fuzz_target.o" \
+        -o "$OUT/$fuzz_target" \
+        $LIB_FUZZING_ENGINE \
+        "avahi-core/.libs/libavahi-core.a" "avahi-common/.libs/libavahi-common.a"
+done
+
+for t in consume-{key,record}; do
+    wget -O "$OUT/fuzz-${t}_seed_corpus.zip" \
+        "https://storage.googleapis.com/avahi-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/avahi_packet_${t//-/_}_fuzzer/public.zip"
+done


### PR DESCRIPTION
to make it easier to maintain them.

It's prompted by https://github.com/lathiat/avahi/pull/459 where the build script has to be edited to disable libsystemd.

This PR is based on https://github.com/google/oss-fuzz/pull/9107 and
includes all those changes as well:

* the fuzz targets are rewritten in C;

* the build script is changed to use the headers and static libraries
  from the the build directory

The license was discussed in https://github.com/google/oss-fuzz/pull/10412#discussion_r1208682267.

~~It's a draft for now. I'll point OSS-Fuzz to this PR to make sure it works.~~ To judge from https://github.com/google/oss-fuzz/pull/10412 it works.