### PR TITLE
Assorted CI tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -25,7 +25,7 @@ case "$1" in
             export CFLAGS="--coverage"
         fi
 
-        ./bootstrap.sh --enable-tests --prefix=/usr
+        ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests --prefix=/usr
         make -j"$(nproc)" V=1
         make check VERBOSE=1
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,6 +4,7 @@ set -eux
 set -o pipefail
 
 export ASAN_UBSAN=${ASAN_UBSAN:-false}
+export BUILD_ONLY=${BUILD_ONLY:-false}
 export COVERAGE=${COVERAGE:-false}
 
 case "$1" in
@@ -27,6 +28,11 @@ case "$1" in
 
         ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests --prefix=/usr
         make -j"$(nproc)" V=1
+
+        if [[ "$BUILD_ONLY" == true ]]; then
+            exit 0
+        fi
+
         make check VERBOSE=1
 
         if [[ "$COVERAGE" == true ]]; then

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,6 +4,7 @@ set -eux
 set -o pipefail
 
 export ASAN_UBSAN=${ASAN_UBSAN:-false}
+export COVERAGE=${COVERAGE:-false}
 
 case "$1" in
     install-build-deps)
@@ -11,7 +12,7 @@ case "$1" in
         apt-get update -y
         apt-get build-dep -y avahi
         apt-get install -y libevent-dev qtbase5-dev
-        apt-get install -y gcc clang
+        apt-get install -y gcc clang lcov
         ;;
     build)
         if [[ "$ASAN_UBSAN" == true ]]; then
@@ -20,9 +21,21 @@ case "$1" in
             export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
         fi
 
+        if [[ "$COVERAGE" == true ]]; then
+            export CFLAGS="--coverage"
+        fi
+
         ./bootstrap.sh --enable-tests --prefix=/usr
         make -j"$(nproc)" V=1
         make check VERBOSE=1
+
+        if [[ "$COVERAGE" == true ]]; then
+            lcov --directory . --capture --initial --output-file coverage.info.initial
+            lcov --directory . --capture --output-file coverage.info.run --no-checksum --rc lcov_branch_coverage=1
+            lcov -a coverage.info.initial -a coverage.info.run --rc lcov_branch_coverage=1 -o coverage.info.raw
+            lcov --extract coverage.info.raw "$(pwd)/*" --rc lcov_branch_coverage=1 --output-file coverage.info
+            exit 0
+        fi
         ;;
     *)
         printf '%s' "Unknown command '$1'" >&2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,26 @@ jobs:
         uses: actions/checkout@v3
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: .github/workflows/build.sh build
+  coverage:
+    if: github.repository == 'lathiat/avahi'
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      checks: write
+    env:
+      CC: "gcc"
+      COVERAGE: "true"
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+      - run: sudo -E .github/workflows/build.sh install-build-deps
+      - run: .github/workflows/build.sh build
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./coverage.info
+          format: lcov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  CC: "gcc"
+  BUILD_ONLY: "true"
+
 jobs:
   analyze:
     name: Analyze
@@ -26,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['cpp', 'python']
+        language: ['cpp', 'python', 'csharp']
 
     steps:
     - name: Checkout repository
@@ -39,8 +43,7 @@ jobs:
 
     - run: sudo -E .github/workflows/build.sh install-build-deps
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - run: .github/workflows/build.sh build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -1,0 +1,43 @@
+---
+# https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme
+
+name: Differential ShellCheck
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/avahi-compat-howl/Makefile.am
+++ b/avahi-compat-howl/Makefile.am
@@ -71,6 +71,11 @@ lib_LTLIBRARIES = libhowl.la
 
 if ENABLE_TESTS
 noinst_PROGRAMS = address-test text-test browse-domain-test
+
+# browser-domain-test is excluded because without avahi-daemon it crashes with:
+# browse-domain-test: browse-domain-test.c:67: main: Assertion `_r == SW_OKAY' failed.
+# Aborted (core dumped)
+TESTS = address-test text-test
 endif
 
 libhowl_la_SOURCES = \

--- a/avahi-compat-libdns_sd/Makefile.am
+++ b/avahi-compat-libdns_sd/Makefile.am
@@ -31,6 +31,8 @@ lib_LTLIBRARIES = libdns_sd.la
 
 if ENABLE_TESTS
 noinst_PROGRAMS = txt-test null-test
+
+TESTS = txt-test null-test
 endif
 
 libdns_sd_la_SOURCES = \


### PR DESCRIPTION
* ci: turn on coverage reports

* ci: build compat-{howl,libdns_sd} as well
    Prompted by https://github.com/lathiat/avahi/pull/465

* make: run the howl and libdns_sd tests automatically
    Prompted by https://github.com/lathiat/avahi/pull/465
    The coverage went from [9.49%](https://coveralls.io/builds/60369370) to [12.944%](https://coveralls.io/builds/60943442) (but long paths aren't tested)

* ci: no longer rely on autobuild
    to get CodeQL to analyze the Python code and the compat libraries
    
* ci: add shellcheck
    Prompted by https://github.com/lathiat/avahi/pull/204

* ci: add dependabot.yml
    https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot