### PR TITLE
libdns_sd: Fix off-by-one error when copying program name in buffer

### DIFF
--- a/avahi-compat-libdns_sd/warn.c
+++ b/avahi-compat-libdns_sd/warn.c
@@ -68,7 +68,7 @@ const char *avahi_exe_name(void) {
             exe_name[k] = 0;
 
             if ((slash = strrchr(exe_name, '/')))
-                memmove(exe_name, slash+1, strlen(slash)+1);
+                memmove(exe_name, slash+1, strlen(slash+1)+1);
         }
     }
 


### PR DESCRIPTION
Fixes copying 1 extra byte which may potentially be outside the buffer if the full program path is long enough.

Using `strlen(slash+1)+1` over the equivalent `strlen(slash)` because it's clearer to read.