### PR TITLE
[common] bail out when escaped labels can't fit into ret

### DIFF
--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -210,7 +210,8 @@ char *avahi_normalize_name(const char *s, char *ret_s, size_t size) {
         } else
             empty = 0;
 
-        avahi_escape_label(label, strlen(label), &r, &size);
+        if (!(avahi_escape_label(label, strlen(label), &r, &size)))
+            return NULL;
     }
 
     return ret_s;

--- a/fuzz/fuzz-domain.c
+++ b/fuzz/fuzz-domain.c
@@ -1,0 +1,52 @@
+/***
+  This file is part of avahi.
+
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+  Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "avahi-common/malloc.h"
+#include "avahi-common/domain.h"
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char *s = NULL, *t = NULL;
+
+    if(!(s = avahi_malloc(size+1)))
+        return 0;
+
+    memcpy(s, data, size);
+    s[size] = '\0';
+
+    if ((t = avahi_normalize_name_strdup(s)))
+        assert(avahi_domain_equal(s, t));
+
+    avahi_is_valid_service_type_generic(s);
+    avahi_is_valid_service_type_strict(s);
+    avahi_is_valid_service_subtype(s);
+    avahi_is_valid_domain_name(s);
+    avahi_is_valid_service_name(s);
+    avahi_is_valid_host_name(s);
+    avahi_is_valid_fqdn(s);
+
+    avahi_free(t);
+    avahi_free(s);
+
+    return 0;
+}


### PR DESCRIPTION
Fixes:
```sh
==93410==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f9e76f14c16 at pc 0x00000047208d bp 0x7ffee90a6a00 sp 0x7ffee90a61c8
READ of size 1110 at 0x7f9e76f14c16 thread T0                                                                                                                 
    #0 0x47208c in __interceptor_strlen (out/fuzz-domain+0x47208c) (BuildId: 731b20c1eef22c2104e75a6496a399b10cfc7cba)                    
    #1 0x534eb0 in avahi_strdup avahi/avahi-common/malloc.c:167:12
    #2 0x53862c in avahi_normalize_name_strdup avahi/avahi-common/domain.c:226:12
```
and
```sh
fuzz-domain: fuzz/fuzz-domain.c:38: int LLVMFuzzerTestOneInput(const uint8_t *, size_t): Assertion `avahi_domain_equal(s, t)' failed.
==101571== ERROR: libFuzzer: deadly signal
    #0 0x501175 in __sanitizer_print_stack_trace (avahi/out/fuzz-domain+0x501175) (BuildId: 682bf6400aff9d41b64b6e2cc3ef5ad600216ea8)              
    #1 0x45ad2c in fuzzer::PrintStackTrace() (avahi/out/fuzz-domain+0x45ad2c) (BuildId: 682bf6400aff9d41b64b6e2cc3ef5ad600216ea8)              
    #2 0x43fc07 in fuzzer::Fuzzer::CrashCallback() (avahi/out/fuzz-domain+0x43fc07) (BuildId: 682bf6400aff9d41b64b6e2cc3ef5ad600216ea8)              
    #3 0x7f1581d7ebaf  (/lib64/libc.so.6+0x3dbaf) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #4 0x7f1581dcf883 in __pthread_kill_implementation (/lib64/libc.so.6+0x8e883) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #5 0x7f1581d7eafd in gsignal (/lib64/libc.so.6+0x3dafd) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #6 0x7f1581d6787e in abort (/lib64/libc.so.6+0x2687e) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #7 0x7f1581d6779a in __assert_fail_base.cold (/lib64/libc.so.6+0x2679a) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #8 0x7f1581d77186 in __assert_fail (/lib64/libc.so.6+0x36186) (BuildId: c9f62793b9e886eb1b95077d4f26fe2b4aa1ac25)
    #9 0x5344a4 in LLVMFuzzerTestOneInput avahi/fuzz/fuzz-domain.c:38:9
```

It's a follow-up to https://github.com/lathiat/avahi/commit/94cb6489114636940ac683515417990b55b5d66c