### PR TITLE
[CI] add a smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { CC: "gcc" }
+          - { CC: "gcc", DISTCHECK: "true", VALGRIND: "true" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
           - { CC: "clang" }
     env: ${{ matrix.env }}

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+look_for_asan_ubsan_reports() {
+    journalctl --sync
+    set +o pipefail
+    pids="$(
+        journalctl -b -u avahi-daemon --grep 'SUMMARY: .*Sanitizer:' |
+        sed -r -n 's/.* .+\[([0-9]+)\]: SUMMARY:.*/\1/p'
+    )"
+    set -o pipefail
+
+    if [[ -n "$pids" ]]; then
+        for pid in $pids; do
+           journalctl -b _PID="$pid" --no-pager
+        done
+        return 1
+    fi
+}
+
+run() {
+    if ! "$@"; then
+        journalctl --sync
+        journalctl -b -u avahi-daemon --no-pager
+        exit 1
+    fi
+}
+
+run systemctl start avahi-daemon
+
+./avahi-client/check-nss-test
+./avahi-client/client-test
+(cd avahi-daemon && ./ini-file-parser-test)
+./avahi-compat-howl/address-test
+./avahi-core/avahi-test
+./examples/glib-integration
+
+systemd-run avahi-browse -varp
+systemd-run avahi-publish -vs test _qotd._tcp 1234 a=1 b
+
+h="$(hostname).local"
+ipv4addr=$(avahi-resolve -v -4 -n "$h" | perl -alpe '$_ = $F[1]')
+ipv6addr=$(avahi-resolve -v -6 -n "$h" | perl -alpe '$_ = $F[1]')
+
+avahi-resolve -v -a "$ipv4addr"
+avahi-resolve -v -a "$ipv6addr"
+
+cmds=(
+    "HELP"
+    "RESOLVE-HOSTNAME $h"
+    "RESOLVE-HOSTNAME-IPV6 $h"
+    "RESOLVE-HOSTNAME-IPV4 $h"
+    "RESOLVE-ADDRESS $ipv4addr"
+    "RESOLVE-ADDRESS $ipv6addr"
+)
+for cmd in "${cmds[@]}"; do
+    printf "%s\n" "$cmd" | nc -U /run/avahi-daemon/socket
+done
+
+avahi-browse -varpt
+avahi-browse -varpc
+
+avahi-set-host-name -v "$(hostname)-new"
+
+run dfuzzer -v -n org.freedesktop.Avahi
+
+run systemctl kill --signal HUP avahi-daemon
+run systemctl kill --signal USR1 avahi-daemon
+run systemctl reload avahi-daemon
+
+run systemctl stop avahi-daemon
+if systemctl is-failed avahi-daemon; then
+    journalctl --sync
+    journalctl -u avahi-daemon --no-pager
+    exit 1
+fi
+
+look_for_asan_ubsan_reports

--- a/avahi-compat-howl/Makefile.am
+++ b/avahi-compat-howl/Makefile.am
@@ -75,7 +75,9 @@ noinst_PROGRAMS = address-test text-test browse-domain-test
 # browser-domain-test is excluded because without avahi-daemon it crashes with:
 # browse-domain-test: browse-domain-test.c:67: main: Assertion `_r == SW_OKAY' failed.
 # Aborted (core dumped)
-TESTS = address-test text-test
+# address-test is excluded because it fails in environments like Packit where
+# gethostbyname is blocked.
+TESTS = text-test
 endif
 
 libhowl_la_SOURCES = \


### PR DESCRIPTION
to make sure avahi more or less works.

It fully installs avahi, starts the service, runs the avahi utils, sends signals, exercises the simple protocol, pokes the D-Bus interface with dfuzzer and runs several tests that can't be run as unit tests. Apart from plain builds it also runs that under ASan/UBSan and Valgrind. Currently it exercises exactly half of the Avahi code base: https://coveralls.io/builds/62803033.

`make distcheck` is run to make sure the tarball is more or less releasable.