### PR TITLE
fuzz: no longer download public OSS-Fuzz corpora

### DIFF
--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -41,8 +41,3 @@ for f in fuzz/fuzz-*.c; do
         $LIB_FUZZING_ENGINE \
         "avahi-core/.libs/libavahi-core.a" "avahi-common/.libs/libavahi-common.a"
 done
-
-for t in consume-{key,record}; do
-    wget -O "$OUT/fuzz-${t}_seed_corpus.zip" \
-        "https://storage.googleapis.com/avahi-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/avahi_packet_${t//-/_}_fuzzer/public.zip"
-done


### PR DESCRIPTION
When the fuzz targets were moved upstream they were renamed to avoid running into issues like
https://github.com/ossf/fuzz-introspector/pull/620. The corpora accumulated by OSS-Fuzz couldn't be renamed though so the idea was to download the old corpora and use them as seed corpora. It worked but now that the old corpora are gone the script can no longer download them and CIFuzz is failing.

CIFuzz downloads the new corpora automatically anyway so it's no longer necessary to keep that part.