### PR TITLE
common: reject single label host names with unescaped trailing dot

### DIFF
--- a/avahi-common/alternative-test.c
+++ b/avahi-common/alternative-test.c
@@ -31,6 +31,9 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     const char* const test_strings[] = {
         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXüüüüüüü",
+        ").",
+        "\\.",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\\\",
         "gurke",
         "-",
         " #",


### PR DESCRIPTION
Previously, alternative host name we created might have ended up being invalid. We consider single label names with trailing dot valid, e.g. "foo.". However, multi label host names are not valid. Hence, for valid host name "foo."  we created alternative "foo.-2" which was invalid and crashed the daemon.

Fixes #451
CVE-2023-38473