### PR TITLE
core: cap maximum size of DNS packet at AVAHI_DNS_PACKET_SIZE_MAX

### DIFF
--- a/avahi-core/dns.c
+++ b/avahi-core/dns.c
@@ -49,6 +49,8 @@ AvahiDnsPacket* avahi_dns_packet_new(unsigned mtu) {
 
     if (max_size < AVAHI_DNS_PACKET_HEADER_SIZE)
         max_size = AVAHI_DNS_PACKET_HEADER_SIZE;
+    else if (max_size > AVAHI_DNS_PACKET_SIZE_MAX)
+        max_size = AVAHI_DNS_PACKET_SIZE_MAX;
 
     if (!(p = avahi_malloc(sizeof(AvahiDnsPacket) + max_size)))
         return p;

--- a/fuzz/fuzz-consume-key.c
+++ b/fuzz/fuzz-consume-key.c
@@ -29,6 +29,10 @@ void log_function(AvahiLogLevel level, const char *txt) {}
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     avahi_set_log_function(log_function);
     AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+
+    if (size + AVAHI_DNS_PACKET_EXTRA_SIZE > AVAHI_DNS_PACKET_SIZE_MAX)
+        size = packet->max_size - AVAHI_DNS_PACKET_EXTRA_SIZE;
+
     memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
     packet->size = size;
     AvahiKey* key = avahi_dns_packet_consume_key(packet, NULL);

--- a/fuzz/fuzz-consume-record.c
+++ b/fuzz/fuzz-consume-record.c
@@ -29,6 +29,10 @@ void log_function(AvahiLogLevel level, const char *txt) {}
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     avahi_set_log_function(log_function);
     AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+
+    if (size + AVAHI_DNS_PACKET_EXTRA_SIZE > AVAHI_DNS_PACKET_SIZE_MAX)
+        size = packet->max_size - AVAHI_DNS_PACKET_EXTRA_SIZE;
+
     memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
     packet->size = size;
     AvahiRecord* rec = avahi_dns_packet_consume_record(packet, NULL);


### PR DESCRIPTION
Fixes #455

CVE-2023-38469