### PR TITLE
core: copy resource records with zero-length rdata properly

### DIFF
--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -426,6 +426,7 @@ AvahiRecord *avahi_record_copy(AvahiRecord *r) {
     copy->ref = 1;
     copy->key = avahi_key_ref(r->key);
     copy->ttl = r->ttl;
+    memset(&copy->data, 0, sizeof(copy->data));
 
     switch (r->key->type) {
         case AVAHI_DNS_TYPE_PTR:
@@ -466,7 +467,7 @@ AvahiRecord *avahi_record_copy(AvahiRecord *r) {
             break;
 
         default:
-            if (!(copy->data.generic.data = avahi_memdup(r->data.generic.data, r->data.generic.size)))
+            if (r->data.generic.size && !(copy->data.generic.data = avahi_memdup(r->data.generic.data, r->data.generic.size)))
                 goto fail;
             copy->data.generic.size = r->data.generic.size;
             break;

--- a/fuzz/fuzz-consume-key.c
+++ b/fuzz/fuzz-consume-key.c
@@ -27,18 +27,31 @@
 void log_function(AvahiLogLevel level, const char *txt) {}
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    AvahiDnsPacket *p = NULL;
+    AvahiKey *k = NULL;
+    int ret;
+
     avahi_set_log_function(log_function);
-    AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
-    memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
-    packet->size = size;
-    AvahiKey* key = avahi_dns_packet_consume_key(packet, NULL);
-    if (key) {
-        avahi_key_is_valid(key);
-        char *s = avahi_key_to_string(key);
-        avahi_free(s);
-        avahi_key_unref(key);
-    }
-    avahi_dns_packet_free(packet);
+
+    if (!(p = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE)))
+        goto finish;
+
+    memcpy(AVAHI_DNS_PACKET_DATA(p), data, size);
+    p->size = size;
+
+    if (!(k = avahi_dns_packet_consume_key(p, NULL)))
+        goto finish;
+
+    ret = avahi_key_is_valid(k);
+    assert(ret);
+
+    avahi_free(avahi_key_to_string(k));
+
+finish:
+    if (k)
+        avahi_key_unref(k);
+    if (p)
+        avahi_dns_packet_free(p);
 
     return 0;
 }

--- a/fuzz/fuzz-consume-record.c
+++ b/fuzz/fuzz-consume-record.c
@@ -23,12 +23,13 @@
 #include "avahi-common/malloc.h"
 #include "avahi-core/dns.h"
 #include "avahi-core/log.h"
+#include "avahi-core/rr-util.h"
 
 void log_function(AvahiLogLevel level, const char *txt) {}
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     AvahiDnsPacket *p = NULL;
-    AvahiRecord *r = NULL;
+    AvahiRecord *r = NULL, *c = NULL;
     int ret;
 
     avahi_set_log_function(log_function);
@@ -45,9 +46,26 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     ret = avahi_record_is_valid(r);
     assert(ret);
 
+    avahi_record_get_estimate_size(r);
+
     avahi_free(avahi_record_to_string(r));
 
+    if (!(c = avahi_record_copy(r)))
+        goto finish;
+
+    ret = avahi_record_equal_no_ttl(r, c);
+    assert(ret);
+
+    avahi_dns_packet_free(p);
+    if (!(p = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE)))
+        goto finish;
+
+    if (!avahi_dns_packet_append_record(p, r, 0, 0))
+        goto finish;
+
 finish:
+    if (c)
+        avahi_record_unref(c);
     if (r)
         avahi_record_unref(r);
     if (p)


### PR DESCRIPTION
It fixes the crash spotted https://github.com/lathiat/avahi/pull/490#issuecomment-1773019619.
The fuzz target was updated to exercise those code paths (among other things). Without this commit it crashes with
 ```sh
    fuzz-consume-record: malloc.c:250: void *avahi_memdup(const void *, size_t): Assertion `s' failed.
    ==72869== ERROR: libFuzzer: deadly signal
        #0 0x5031b5 in __sanitizer_print_stack_trace (avahi/out/fuzz-consume-record+0x5031b5) (BuildId: 69840d811c9ba9f74eea21e34786a2005c5dcc06)
        #1 0x45cd6c in fuzzer::PrintStackTrace() (avahi/out/fuzz-consume-record+0x45cd6c) (BuildId: 69840d811c9ba9f74eea21e34786a2005c5dcc06)
        #2 0x441c47 in fuzzer::Fuzzer::CrashCallback() (out/fuzz-consume-record+0x441c47) (BuildId: 69840d811c9ba9f74eea21e34786a2005c5dcc06)
        #3 0x7f189e97ebaf  (/lib64/libc.so.6+0x3dbaf) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #4 0x7f189e9cf883 in __pthread_kill_implementation (/lib64/libc.so.6+0x8e883) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #5 0x7f189e97eafd in gsignal (/lib64/libc.so.6+0x3dafd) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #6 0x7f189e96787e in abort (/lib64/libc.so.6+0x2687e) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #7 0x7f189e96779a in __assert_fail_base.cold (/lib64/libc.so.6+0x2679a) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #8 0x7f189e977186 in __assert_fail (/lib64/libc.so.6+0x36186) (BuildId: 3ebe8d97a0ed3e1f13476a02665c5a9442adcd78)
        #9 0x557bfc in avahi_memdup avahi/avahi-common/malloc.c:250:5
        #10 0x54895c in avahi_record_copy avahi/avahi-core/rr.c:469:45
```
