### PR TITLE
core: extract host name using avahi_unescape_label()

### DIFF
--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -1295,7 +1295,11 @@ static void update_fqdn(AvahiServer *s) {
 }
 
 int avahi_server_set_host_name(AvahiServer *s, const char *host_name) {
-    char *hn = NULL;
+    char label_escaped[AVAHI_LABEL_MAX*4+1];
+    char label[AVAHI_LABEL_MAX];
+    char *hn = NULL, *h;
+    size_t len;
+
     assert(s);
 
     AVAHI_CHECK_VALIDITY(s, !host_name || avahi_is_valid_host_name(host_name), AVAHI_ERR_INVALID_HOST_NAME);
@@ -1305,17 +1309,28 @@ int avahi_server_set_host_name(AvahiServer *s, const char *host_name) {
     else
         hn = avahi_normalize_name_strdup(host_name);
 
-    hn[strcspn(hn, ".")] = 0;
-
-    if (avahi_domain_equal(s->host_name, hn) && s->state != AVAHI_SERVER_COLLISION) {
-        avahi_free(hn);
-        return avahi_server_set_errno(s, AVAHI_ERR_NO_CHANGE);
+    h = hn;
+    if (!avahi_unescape_label((const char **)&hn, label, sizeof(label))) {
+        avahi_free(h);
+        return AVAHI_ERR_INVALID_HOST_NAME;
     }
+
+    avahi_free(h);
+
+    h = label_escaped;
+    len = sizeof(label_escaped);
+    if (!avahi_escape_label(label, strlen(label), &h, &len))
+        return AVAHI_ERR_INVALID_HOST_NAME;
+
+    if (avahi_domain_equal(s->host_name, label_escaped) && s->state != AVAHI_SERVER_COLLISION)
+        return avahi_server_set_errno(s, AVAHI_ERR_NO_CHANGE);
 
     withdraw_host_rrs(s);
 
     avahi_free(s->host_name);
-    s->host_name = hn;
+    s->host_name = avahi_strdup(label_escaped);
+    if (!s->host_name)
+        return AVAHI_ERR_NO_MEMORY;
 
     update_fqdn(s);
 


### PR DESCRIPTION
Previously we could create invalid escape sequence when we split the string on dot. For example, from valid host name "foo\\.bar" we have created invalid name "foo\\" and tried to set that as the host name which crashed the daemon.

Fixes #453

CVE-2023-38471