### PR TITLE
core: reject overly long TXT resource records

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -40,6 +40,12 @@ run systemctl start avahi-daemon
 systemd-run avahi-browse -varp
 systemd-run avahi-publish -vs test _qotd._tcp 1234 a=1 b
 
+# https://github.com/lathiat/avahi/issues/455
+# The idea is to produce a lot of arguments by splitting the output
+# of the perl one-liner so it shouldn't be quoted.
+# shellcheck disable=SC2046
+avahi-publish -s T _qotd._tcp 22 $(perl -le 'print "A " x 100000')
+
 h="$(hostname).local"
 ipv4addr=$(avahi-resolve -v -4 -n "$h" | perl -alpe '$_ = $F[1]')
 ipv6addr=$(avahi-resolve -v -6 -n "$h" | perl -alpe '$_ = $F[1]')

--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -32,6 +32,7 @@
 #include <avahi-common/malloc.h>
 #include <avahi-common/defs.h>
 
+#include "dns.h"
 #include "rr.h"
 #include "log.h"
 #include "util.h"
@@ -689,10 +690,16 @@ int avahi_record_is_valid(AvahiRecord *r) {
         case AVAHI_DNS_TYPE_TXT: {
 
             AvahiStringList *strlst;
+            size_t used = 0;
 
-            for (strlst = r->data.txt.string_list; strlst; strlst = strlst->next)
+            for (strlst = r->data.txt.string_list; strlst; strlst = strlst->next) {
                 if (strlst->size > 255 || strlst->size <= 0)
                     return 0;
+
+                used += 1+strlst->size;
+                if (used > AVAHI_DNS_RDATA_MAX)
+                    return 0;
+            }
 
             return 1;
         }


### PR DESCRIPTION
Closes https://github.com/lathiat/avahi/issues/455

CVE-2023-38469

The tests were updated to make sure overly long TXT RRs no longer crash avahi.