### PR TITLE
ci: put the libraries in the right place

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -54,7 +54,8 @@ case "$1" in
         fi
         export CXXFLAGS="$CFLAGS"
 
-        ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests --prefix=/usr
+        ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests \
+            --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
         make -j"$(nproc)" V=1
 
         if [[ "$BUILD_ONLY" == true ]]; then
@@ -96,6 +97,7 @@ case "$1" in
         printf "2001:db8::1 static-host-test.local\n" >>avahi-daemon/hosts
 
         sudo make install
+        sudo ldconfig
         sudo adduser --system --group avahi
         sudo systemctl reload dbus
         sudo .github/workflows/smoke-tests.sh


### PR DESCRIPTION
to prevent avahi from failing to start with
```
avahi-daemon[23549]: avahi-daemon: starting up: symbol lookup error: /lib/libavahi-core.so.7: undefined symbol: avahi_now
```
when the system libraries get mixed up with the newly built libraries.

(It was spotted in a PR where the libcommon library was pulled as a dependency somewhere and the smoke test failed because of that)