### PR TITLE
core: compare RRs with zero-length rdata correctly

### DIFF
--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -547,7 +547,7 @@ static int lexicographical_memcmp(const void* a, size_t al, const void* b, size_
     if (al == bl)
         return 0;
     else
-        return al == c ? 1 : -1;
+        return al == c ? -1 : 1;
 }
 
 static int uint16_cmp(uint16_t a, uint16_t b) {
@@ -640,9 +640,23 @@ int avahi_record_lexicographical_compare(AvahiRecord *a, AvahiRecord *b) {
         case AVAHI_DNS_TYPE_AAAA:
             return memcmp(&a->data.aaaa.address, &b->data.aaaa.address, sizeof(AvahiIPv6Address));
 
-        default:
-            return lexicographical_memcmp(a->data.generic.data, a->data.generic.size,
-                                          b->data.generic.data, b->data.generic.size);
+        default: {
+            size_t asize, bsize;
+
+            asize = a->data.generic.size;
+            bsize = b->data.generic.size;
+
+            if (asize && bsize)
+                r = lexicographical_memcmp(a->data.generic.data, asize, b->data.generic.data, bsize);
+            else if (asize && !bsize)
+                r = 1;
+            else if (!asize && bsize)
+                r = -1;
+            else
+                r = 0;
+
+            return r;
+        }
     }
 
 

--- a/fuzz/fuzz-consume-record.c
+++ b/fuzz/fuzz-consume-record.c
@@ -67,11 +67,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     ret = avahi_record_equal_no_ttl(r, rs);
     assert(ret);
 
+    ret = avahi_record_lexicographical_compare(r, rs);
+    assert(ret == 0);
+
     if (!(c = avahi_record_copy(r)))
         goto finish;
 
     ret = avahi_record_equal_no_ttl(r, c);
     assert(ret);
+
+    ret = avahi_record_lexicographical_compare(r, c);
+    assert(ret == 0);
 
     avahi_dns_packet_free(p);
     if (!(p = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE)))


### PR DESCRIPTION
RRs where types are unknown to avahi can't be passed to
lexicographical_memcmp directly because it doesn't expect NULL pointers
and crashes. This patch prevents it from crashing by treating those NULL
pointers as empty strings and returning -1, 0 or 1. It in turn prevents
avahi from crashing on receiving probes with zero-length rdata if
unusual RRs have ever been added using avahi_entry_group_add_record.

This patch also fixes a bug where RRs with no remaining bytes were
deemed lexicographically later even though according to
https://datatracker.ietf.org/doc/html/rfc6762#section-8.2

The bytes of the raw uncompressed rdata are compared ...
until a byte is found whose value is greater than that of its counterpart
... or one of the resource records runs out of rdata (in which case,
the resource record which still has remaining data first is deemed
lexicographically later)

The test were added to make sure it actually works as expected and the fuzz
target was updated to make sure it no longer crashes anywhere.

Closes https://github.com/lathiat/avahi/issues/493