### PR TITLE
fuzz: fuzz full DNS packets

### DIFF
--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -79,8 +79,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     avahi_service_name_split(t, NULL, 0, type, sizeof(type), domain, sizeof(domain));
     printf("name: <>; type: <%s>; domain <%s>\n", type, domain);
 
-
-    p = "--:---\\\\\\123\\065_äöü\\064\\.\\\\sjöödfhh.sdfjhskjdf";
+    p = "--:---\\\\\\123\\065_\344\366\374\\064\\.\\\\sj\366\366dfhh.sdfjhskjdf";
     printf("unescaped: <%s>, rest: %s\n", avahi_unescape_label(&p, t, sizeof(t)), p);
 
     size = sizeof(r);

--- a/avahi-common/utf8-test.c
+++ b/avahi-common/utf8-test.c
@@ -30,9 +30,15 @@
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     assert(avahi_utf8_valid("hallo"));
+    assert(avahi_utf8_valid("1234567890."));
     /* same word in iso-8859-1 as utf-8 below. */
     assert(!avahi_utf8_valid("\xfcxkn\xfcrz"));
     assert(avahi_utf8_valid("üxknürz"));
+    assert(avahi_utf8_valid("žluťoučký kůň pěl ďábelské ódy"));
+    /* few examples from https://www.iana.org/domains/reserved */
+    assert(avahi_utf8_valid("испытание"));
+    assert(avahi_utf8_valid("δοκιμή"));
+    assert(avahi_utf8_valid("テスト"));
 
     return 0;
 }

--- a/avahi-common/utf8-test.c
+++ b/avahi-common/utf8-test.c
@@ -30,7 +30,8 @@
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     assert(avahi_utf8_valid("hallo"));
-    assert(!avahi_utf8_valid("üxknürz"));
+    /* same word in iso-8859-1 as utf-8 below. */
+    assert(!avahi_utf8_valid("\xfcxkn\xfcrz"));
     assert(avahi_utf8_valid("Ã¼xknÃ¼rz"));
 
     return 0;

--- a/fuzz/fuzz-packet.c
+++ b/fuzz/fuzz-packet.c
@@ -1,0 +1,101 @@
+/***
+  This file is part of avahi.
+
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+  Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "avahi-common/malloc.h"
+#include "avahi-core/dns.h"
+#include "avahi-core/log.h"
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+bool copy_rrs(AvahiDnsPacket *from, AvahiDnsPacket *to, unsigned idx) {
+    for (uint16_t n = avahi_dns_packet_get_field(from, idx); n > 0; n--) {
+        AvahiRecord *record;
+        int cache_flush = 0;
+        uint8_t *res;
+
+        if (!(record = avahi_dns_packet_consume_record(from, &cache_flush)))
+            return false;
+
+        res = avahi_dns_packet_append_record(to, record, cache_flush, 0);
+        avahi_record_unref(record);
+        if (!res)
+            return false;
+        avahi_dns_packet_inc_field(to, idx);
+    }
+    return true;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    AvahiDnsPacket *p1 = NULL, *p2 = NULL;
+
+    if (size > AVAHI_DNS_PACKET_SIZE_MAX)
+        return 0;
+
+    avahi_set_log_function(log_function);
+
+    if (!(p1 = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE)))
+        goto finish;
+
+    memcpy(AVAHI_DNS_PACKET_DATA(p1), data, size);
+    p1->size = size;
+
+    if (avahi_dns_packet_check_valid(p1) < 0)
+        goto finish;
+
+    if (!(p2 = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE)))
+        goto finish;
+
+    avahi_dns_packet_set_field(p2, AVAHI_DNS_FIELD_ID, avahi_dns_packet_get_field(p1, AVAHI_DNS_FIELD_ID));
+
+    for (uint16_t n = avahi_dns_packet_get_field(p1, AVAHI_DNS_FIELD_QDCOUNT); n > 0; n--) {
+        AvahiKey *key;
+        int unicast_response = 0;
+        uint8_t *res;
+
+        if (!(key = avahi_dns_packet_consume_key(p1, &unicast_response)))
+            goto finish;
+
+        res = avahi_dns_packet_append_key(p2, key, unicast_response);
+        avahi_key_unref(key);
+        if (!res)
+            goto finish;
+        avahi_dns_packet_inc_field(p2, AVAHI_DNS_FIELD_QDCOUNT);
+    }
+
+    if (!copy_rrs(p1, p2, AVAHI_DNS_FIELD_ANCOUNT))
+        goto finish;
+
+    if (!copy_rrs(p1, p2, AVAHI_DNS_FIELD_NSCOUNT))
+        goto finish;
+
+    if (!copy_rrs(p1, p2, AVAHI_DNS_FIELD_ARCOUNT))
+        goto finish;
+
+finish:
+    if (p2)
+        avahi_dns_packet_free(p2);
+    if (p1)
+        avahi_dns_packet_free(p1);
+
+    return 0;
+}

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -41,3 +41,8 @@ for f in fuzz/fuzz-*.c; do
         $LIB_FUZZING_ENGINE \
         "avahi-core/.libs/libavahi-core.a" "avahi-common/.libs/libavahi-common.a"
 done
+
+# Let's take the systemd public corpus here. It has been accumulating since 2018
+# so it should be good enough for our purposes.
+wget -O "$OUT/fuzz-packet_seed_corpus.zip" \
+    https://storage.googleapis.com/systemd-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/systemd_fuzz-dns-packet/public.zip


### PR DESCRIPTION
to exercise message compression/decompression and various various getters/setters.

I also extracted a couple of commits related to the utf8 tests from https://github.com/lathiat/avahi/pull/481.