### PR TITLE
common: make avahi_is_valid_service_name reject non-UTF-8 service names

### DIFF
--- a/avahi-common/alternative-test.c
+++ b/avahi-common/alternative-test.c
@@ -88,6 +88,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
         }
     }
 
+    avahi_alternative_service_name("\xc1\x0a");
+
     avahi_free(r);
     return 0;
 }

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -397,7 +397,7 @@ int avahi_is_valid_domain_name(const char *t) {
 int avahi_is_valid_service_name(const char *t) {
     assert(t);
 
-    if (strlen(t) >= AVAHI_LABEL_MAX || !*t)
+    if (strlen(t) >= AVAHI_LABEL_MAX || !*t || !avahi_utf8_valid(t))
         return 0;
 
     return 1;

--- a/fuzz/fuzz-domain.c
+++ b/fuzz/fuzz-domain.c
@@ -47,6 +47,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     avahi_is_valid_fqdn(s);
 
     avahi_free(avahi_alternative_host_name(s));
+    avahi_free(avahi_alternative_service_name(s));
 
     avahi_free(t);
     avahi_free(s);


### PR DESCRIPTION
All the functions receiving service names expect them to be UTF-8. When they aren't those functions can crash. For example here's how avahi_alternative_service_name crashed without this patch:
```
alternative-test: alternative.c:44: drop_incomplete_utf8: Assertion `*e & 128' failed.

  #0  0x00007ffff76b0884 in __pthread_kill_implementation () from /lib64/libc.so.6
  #1  0x00007ffff765fafe in raise () from /lib64/libc.so.6
  #2  0x00007ffff764887f in abort () from /lib64/libc.so.6
  #3  0x00007ffff764879b in __assert_fail_base.cold () from /lib64/libc.so.6
  #4  0x00007ffff7658187 in __assert_fail () from /lib64/libc.so.6
  #5  0x000000000040257b in drop_incomplete_utf8 (c=0x60200003bed0 "\301\n") at alternative.c:44
  #6  0x00000000004033b2 in avahi_alternative_service_name (s=0x40ff00 "\301\n") at alternative.c:184
  #7  0x000000000040b722 in main (argc=1, argv=0x7fffffffe1c8) at alternative-test.c:91
```
The test is added to make sure avahi_alternative_service_name no longer crashes. The fuzz target is updated to make sure
avahi_alternative_service_name can withstand all sorts of service names.