### PR TITLE
core: no longer supply bogus services to callbacks

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -39,6 +39,7 @@ run systemctl start avahi-daemon
 
 systemd-run avahi-browse -varp
 systemd-run avahi-publish -vs test _qotd._tcp 1234 a=1 b
+systemd-run avahi-publish -s --subtype _beep._sub._qotd._tcp BOOP _qotd._tcp 1234
 
 # https://github.com/lathiat/avahi/issues/455
 # The idea is to produce a lot of arguments by splitting the output
@@ -77,6 +78,7 @@ done >&/dev/null' || true
 
 avahi-browse -varpt
 avahi-browse -varpc
+[[ -n "$(avahi-browse -vrpc _beep._sub._qotd._tcp)" ]]
 
 avahi-set-host-name -v 'A\.B'
 avahi-set-host-name -v "$(perl -e 'print(q/[/x63)')"

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -501,12 +501,17 @@ int avahi_service_name_split(const char *p, char *name, size_t name_size, char *
         DOMAIN
     } state;
     int type_empty = 1, domain_empty = 1;
+    char *oname, *otype, *odomain;
 
     assert(p);
     assert(type);
     assert(type_size > 0);
     assert(domain);
     assert(domain_size > 0);
+
+    oname = name;
+    otype = type;
+    odomain = domain;
 
     if (name) {
         assert(name_size > 0);
@@ -569,6 +574,15 @@ int avahi_service_name_split(const char *p, char *name, size_t name_size, char *
                 break;
         }
     }
+
+    if ((oname && !avahi_is_valid_service_name(oname)))
+        return AVAHI_ERR_INVALID_SERVICE_NAME;
+
+    if (!avahi_is_valid_service_type_generic(otype))
+        return AVAHI_ERR_INVALID_SERVICE_TYPE;
+
+    if (!avahi_is_valid_domain_name(odomain))
+        return AVAHI_ERR_INVALID_DOMAIN_NAME;
 
     return 0;
 }

--- a/avahi-core/browse-service-type.c
+++ b/avahi-core/browse-service-type.c
@@ -65,7 +65,7 @@ static void record_browser_callback(
         assert(record->key->type == AVAHI_DNS_TYPE_PTR);
 
         if (avahi_service_name_split(record->data.ptr.name, NULL, 0, type, sizeof(type), domain, sizeof(domain)) < 0) {
-            avahi_log_warn("Invalid service type '%s'", record->key->name);
+            avahi_log_debug("Failed to split service name '%s'", record->data.ptr.name);
             return;
         }
 

--- a/avahi-core/browse-service.c
+++ b/avahi-core/browse-service.c
@@ -69,7 +69,7 @@ static void record_browser_callback(
             flags |= AVAHI_LOOKUP_RESULT_LOCAL;
 
         if (avahi_service_name_split(record->data.ptr.name, service, sizeof(service), type, sizeof(type), domain, sizeof(domain)) < 0) {
-            avahi_log_warn("Failed to split '%s'", record->key->name);
+            avahi_log_debug("Failed to split service name '%s'", record->data.ptr.name);
             return;
         }
 

--- a/fuzz/fuzz-packet.c
+++ b/fuzz/fuzz-packet.c
@@ -53,17 +53,17 @@ bool copy_rrs(AvahiDnsPacket *from, AvahiDnsPacket *to, unsigned idx) {
         if (record->key->type == AVAHI_DNS_TYPE_PTR) {
             char service[AVAHI_LABEL_MAX], type[AVAHI_DOMAIN_NAME_MAX], domain[AVAHI_DOMAIN_NAME_MAX];
             char name[AVAHI_DOMAIN_NAME_MAX];
+            int res;
 
-            /* Ideally there should also be assertions to make sure that all the components
-             * can be joined back together successfully but in its current form avahi_service_name_split
-             * can supply invalid arguments rejected by avahi_service_name_join and that's where
-             * issues like https://github.com/lathiat/avahi/issues/212 come from. Let's just exercise
-             * those code paths for now to at least make sure they don't crash. */
-            if (avahi_service_name_split(record->data.ptr.name, service, sizeof(service), type, sizeof(type), domain, sizeof(domain)) >= 0)
-                avahi_service_name_join(name, sizeof(name), service, type, domain);
+            if (avahi_service_name_split(record->data.ptr.name, service, sizeof(service), type, sizeof(type), domain, sizeof(domain)) >= 0) {
+                res = avahi_service_name_join(name, sizeof(name), service, type, domain);
+                assert(res >= 0);
+            }
 
-            if (avahi_service_name_split(record->data.ptr.name, NULL, 0, type, sizeof(type), domain, sizeof(domain)) >= 0)
-                avahi_service_name_join(name, sizeof(name), NULL, type, domain);
+            if (avahi_service_name_split(record->data.ptr.name, NULL, 0, type, sizeof(type), domain, sizeof(domain)) >= 0) {
+                res = avahi_service_name_join(name, sizeof(name), NULL, type, domain);
+                assert(res >= 0);
+            }
         }
 
         res = avahi_dns_packet_append_record(to, record, cache_flush, 0);


### PR DESCRIPTION
It was technically a DOS allowing packets with service names like "bogus.service.local" to bring down `avahi-browse -a`. In practice it was usually triggered by misconfigured smart devices but it isn't that hard to forge packets like that and send them deliberately.

The tests are added to make sure invalid service names are rejected and valid service names keep working. The fuzz target is updated to make sure that avahi_service_name_split always supplies valid arguments to avahi_service_name_join. avahi now logs what exactly it fails to split
```
avahi-daemon[176]: Failed to split service name '0.1.9.1.8.8.e.f.f.f.f.a.a.1.4.7.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa'
avahi-daemon[176]: Failed to split service name 'bogus\032.\032\209\129\208\181\209\128\208\178\208\184\209\129.local'
avahi-daemon[176]: Failed to split service name '255.20.254.169.in-addr.arpa'
avahi-daemon[176]: Failed to split service name 'bogus\032.\032\209\129\208\181\209\128\208\178\208\184\209\129.local'
avahi-daemon[176]: Failed to split service name '33.93.168.192.in-addr.arpa'
```
when --debug is passed to it (which makes that part consistent with the other places where weird packets are rejected).

Closes https://github.com/lathiat/avahi/issues/212